### PR TITLE
fix: use broader cookie domain

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -26,5 +26,6 @@ applications:
       OPTIMIZE_MEMORY: true
       PUBLIC_URL: https://pages-editor-((env)).app.cloud.gov
       PREVIEW_URL: https://pages-editor-preview-((env)).app.cloud.gov
+      COOKIE_DOMAIN: app.cloud.gov
     health-check-type: http
     health-check-http-endpoint: /admin

--- a/.profile
+++ b/.profile
@@ -2,4 +2,3 @@ export DATABASE_URI="$DATABASE_URL"?sslmode=require
 export PAYLOAD_SECRET="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "pages-editor-creds" ".[][] | select(.name == \$service_name) | .credentials.PAYLOAD_SECRET")"
 export OAUTH_CLIENT_ID="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "pages-editor-creds" ".[][] | select(.name == \$service_name) | .credentials.OAUTH_CLIENT_ID")"
 export OAUTH_CLIENT_SECRET="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "pages-editor-creds" ".[][] | select(.name == \$service_name) | .credentials.OAUTH_CLIENT_SECRET")"
-export PREVIEW_URL="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "pages-editor-creds" ".[][] | select(.name == \$service_name) | .credentials.PREVIEW_URL")"

--- a/src/collections/Users/index.ts
+++ b/src/collections/Users/index.ts
@@ -18,7 +18,10 @@ export const Users: CollectionConfig = {
   },
   auth: {
     disableLocalStrategy: true,
-    useAPIKey: true
+    useAPIKey: true,
+    cookies: {
+      domain: process.env.COOKIE_DOMAIN
+    }
   },
   fields: [
     {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Use `app.cloud.gov` as the cookie domain

## Security considerations
For testing purposes, we need to use `app.cloud.gov` as the cookie domain, we should restrict this further in the future