### PR TITLE
Feat reorganize admin dashboard

### DIFF
--- a/src/app/(payload)/custom.scss
+++ b/src/app/(payload)/custom.scss
@@ -38,13 +38,6 @@
     line-height: 25px;
 }
 
-.render-title {
-    font-family: "Merriweather", Georgia, Cambria, "Times New Roman", Times, serif;
-    font-weight: 700;
-}
-
-// the button styles mess up with main page links so
-// restrict them a bit
 .list-header, .doc-controls__wrapper, .login {
     .btn {
         @extend .usa-button;
@@ -74,4 +67,18 @@ button {
     display: flex;
     justify-content: center;
     width: 100%;
+}
+
+.list-header__title-and-actions {
+    justify-content: space-between;
+    padding-bottom: 0.5rem;
+}
+
+.table {
+    th:first-child,
+    td:first-child {
+        width: 40px !important;
+        min-width: 40px;
+        max-width: 40px;
+    }
 }

--- a/src/collections/Categories/index.ts
+++ b/src/collections/Categories/index.ts
@@ -13,6 +13,8 @@ export const Categories: CollectionConfig = {
     update: getAdminOrSiteUser('reports'),
   },
   admin: {
+    group: 'Global Assets',
+    description: 'Content categories and tags',
     useAsTitle: 'title',
     hidden: false,
   },

--- a/src/collections/Events/index.ts
+++ b/src/collections/Events/index.ts
@@ -11,18 +11,9 @@ import { descriptionField, imageField } from '@/fields'
 
 export const Events: CollectionConfig<'events'> = {
   slug: 'events',
-  access: {
-    create: getAdminOrSiteUser('events'),
-    delete: getAdminOrSiteUser('events'),
-    read: getAdminOrSiteUser('events', ['manager', 'user', 'bot']),
-    update: getAdminOrSiteUser('events'),
-  },
-  defaultPopulate: {
-    title: true,
-    slug: true,
-  },
-  defaultSort: '-reviewReady',
   admin: {
+    group: 'Collections',
+    description: 'Events and calendar items',
     defaultColumns: ['title', 'reviewReady', 'updatedAt'],
     livePreview: {
       url: async ({ data, req }) => {
@@ -41,6 +32,17 @@ export const Events: CollectionConfig<'events'> = {
     useAsTitle: 'title',
     hideAPIURL: true,
   },
+  access: {
+    create: getAdminOrSiteUser('events'),
+    delete: getAdminOrSiteUser('events'),
+    read: getAdminOrSiteUser('events', ['manager', 'user', 'bot']),
+    update: getAdminOrSiteUser('events'),
+  },
+  defaultPopulate: {
+    title: true,
+    slug: true,
+  },
+  defaultSort: '-reviewReady',
   fields: [
     {
       name: 'title',

--- a/src/collections/Leadership/index.ts
+++ b/src/collections/Leadership/index.ts
@@ -10,19 +10,13 @@ import { publish } from '@/hooks/publish'
 
 export const Leadership: CollectionConfig<'leadership'> = {
   slug: 'leadership',
-  access: {
-    create: getAdminOrSiteUser('leadership'),
-    delete: getAdminOrSiteUser('leadership'),
-    read: getAdminOrSiteUser('leadership', ['manager', 'user', 'bot']),
-    update: getAdminOrSiteUser('leadership'),
-  },
-  defaultPopulate: {
-    title: true,
-    slug: true,
-    jobTitle: true,
-    image: true,
+  labels: {
+    singular: 'Leadership',
+    plural: 'Leadership',
   },
   admin: {
+    group: 'Collections',
+    description: 'Leadership team members',
     defaultColumns: ['title', 'jobTitle', 'slug', 'updatedAt'],
     livePreview: {
       url: async ({ data, req }) => {
@@ -38,6 +32,18 @@ export const Leadership: CollectionConfig<'leadership'> = {
     },
     useAsTitle: 'title',
     hideAPIURL: true,
+  },
+  access: {
+    create: getAdminOrSiteUser('leadership'),
+    delete: getAdminOrSiteUser('leadership'),
+    read: getAdminOrSiteUser('leadership', ['manager', 'user', 'bot']),
+    update: getAdminOrSiteUser('leadership'),
+  },
+  defaultPopulate: {
+    title: true,
+    slug: true,
+    jobTitle: true,
+    image: true,
   },
   fields: [
     {

--- a/src/collections/Media/index.ts
+++ b/src/collections/Media/index.ts
@@ -12,6 +12,8 @@ const dirname = path.dirname(filename)
 
 export const Media: CollectionConfig = {
   admin: {
+    group: 'Global Assets',
+    description: 'Images, documents, and media files',
     hidden: false,
     defaultColumns: ['filename', '_status', 'reviewReady'],
   },

--- a/src/collections/News/index.ts
+++ b/src/collections/News/index.ts
@@ -11,18 +11,9 @@ import { completeReview } from '@/hooks/completeReview'
 
 export const News: CollectionConfig<'news'> = {
   slug: 'news',
-  access: {
-    create: getAdminOrSiteUser('news'),
-    delete: getAdminOrSiteUser('news'),
-    read: getAdminOrSiteUser('news', ['manager', 'user', 'bot']),
-    update: getAdminOrSiteUser('news'),
-  },
-  defaultPopulate: {
-    title: true,
-    slug: true,
-  },
-  defaultSort: '-reviewReady',
   admin: {
+    group: 'Collections',
+    description: 'News articles and announcements',
     defaultColumns: ['title', 'reviewReady', 'updatedAt'],
     livePreview: {
       url: async ({ data, req }) => {
@@ -41,6 +32,17 @@ export const News: CollectionConfig<'news'> = {
     useAsTitle: 'title',
     hideAPIURL: true,
   },
+  access: {
+    create: getAdminOrSiteUser('news'),
+    delete: getAdminOrSiteUser('news'),
+    read: getAdminOrSiteUser('news', ['manager', 'user', 'bot']),
+    update: getAdminOrSiteUser('news'),
+  },
+  defaultPopulate: {
+    title: true,
+    slug: true,
+  },
+  defaultSort: '-reviewReady',
   fields: [
     {
       name: 'title',

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -11,20 +11,10 @@ import { completeReview } from '@/hooks/completeReview'
 
 export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
-  access: {
-    create: getAdminOrSiteUser('pages', ['manager', 'user']),
-    delete: getAdmin,
-    read: getAdminOrSiteUser('pages', ['manager', 'user', 'bot']),
-    update: getAdminOrSiteUser('pages'),
-  },
-  defaultPopulate: {
-    title: true,
-    slug: true,
-  },
-  defaultSort: '-reviewReady',
   admin: {
+    group: 'Standalone Pages',
+    description: 'Individual website pages',
     defaultColumns: ['title', 'slug', 'reviewReady', 'updatedAt'],
-    description: 'Manage single pages that are shown in the site.',
     livePreview: {
       url: async ({ data, req }) => {
         // site isn't fetched at the necessary depth in `data`
@@ -41,8 +31,18 @@ export const Pages: CollectionConfig<'pages'> = {
     },
     useAsTitle: 'title',
     hideAPIURL: true,
-    group: 'Individual Pages',
   },
+  access: {
+    create: getAdminOrSiteUser('pages', ['manager', 'user']),
+    delete: getAdmin,
+    read: getAdminOrSiteUser('pages', ['manager', 'user', 'bot']),
+    update: getAdminOrSiteUser('pages'),
+  },
+  defaultPopulate: {
+    title: true,
+    slug: true,
+  },
+  defaultSort: '-reviewReady',
   fields: [
     {
       name: 'title',

--- a/src/collections/Policies/index.ts
+++ b/src/collections/Policies/index.ts
@@ -11,20 +11,10 @@ import { siteField } from '@/fields/relationships'
 
 export const Policies: CollectionConfig<'policies'> = {
   slug: 'policies',
-  access: {
-    create: getAdmin,
-    delete: getAdmin,
-    read: getAdminOrSiteUser('policies', ['manager', 'user', 'bot']),
-    update: getAdminOrSiteUser('policies'),
-  },
-  defaultPopulate: {
-    title: true,
-    slug: true,
-  },
-  defaultSort: '-reviewReady',
   admin: {
+    group: 'Standalone Pages',
+    description: 'Policies and procedures',
     defaultColumns: ['title', 'slug', 'reviewReady', 'updatedAt'],
-    description: 'Manage policies that are shown in the site.',
     livePreview: {
       url: async ({ data, req }) => {
         // site isn't fetched at the necessary depth in `data`
@@ -41,8 +31,18 @@ export const Policies: CollectionConfig<'policies'> = {
     },
     useAsTitle: 'title',
     hideAPIURL: true,
-    group: 'Individual Pages',
   },
+  access: {
+    create: getAdmin,
+    delete: getAdmin,
+    read: getAdminOrSiteUser('policies', ['manager', 'user', 'bot']),
+    update: getAdminOrSiteUser('policies'),
+  },
+  defaultPopulate: {
+    title: true,
+    slug: true,
+  },
+  defaultSort: '-reviewReady',
   fields: [
     {
       name: 'title',

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -14,20 +14,9 @@ import { publish } from '@/hooks/publish'
 
 export const Posts: CollectionConfig<'posts'> = {
   slug: 'posts',
-  access: {
-    create: getAdminOrSiteUser('posts'),
-    delete: getAdminOrSiteUser('posts'),
-    read: getAdminOrSiteUser('posts', ['manager', 'user', 'bot']),
-    update: getAdminOrSiteUser('posts'),
-  },
-  // This config controls what's populated by default when a post is referenced
-  // https://payloadcms.com/docs/queries/select#defaultpopulate-collection-config-property
-  // Type safe if the collection slug generic is passed to `CollectionConfig` - `CollectionConfig<'posts'>
-  defaultPopulate: {
-    title: true,
-    slug: true,
-  },
   admin: {
+    group: 'Collections',
+    description: 'Blog posts and articles',
     defaultColumns: ['title', 'slug', 'updatedAt'],
     livePreview: {
       url: async ({ data, req }) => {
@@ -45,6 +34,19 @@ export const Posts: CollectionConfig<'posts'> = {
     },
     useAsTitle: 'title',
     hideAPIURL: true,
+  },
+  access: {
+    create: getAdminOrSiteUser('posts'),
+    delete: getAdminOrSiteUser('posts'),
+    read: getAdminOrSiteUser('posts', ['manager', 'user', 'bot']),
+    update: getAdminOrSiteUser('posts'),
+  },
+  // This config controls what's populated by default when a post is referenced
+  // https://payloadcms.com/docs/queries/select#defaultpopulate-collection-config-property
+  // Type safe if the collection slug generic is passed to `CollectionConfig` - `CollectionConfig<'posts'>
+  defaultPopulate: {
+    title: true,
+    slug: true,
   },
   fields: [
     {

--- a/src/collections/Reports/index.ts
+++ b/src/collections/Reports/index.ts
@@ -11,17 +11,13 @@ import { completeReview } from '@/hooks/completeReview'
 
 export const Reports: CollectionConfig<'reports'> = {
   slug: 'reports',
-  access: {
-    create: getAdminOrSiteUser('reports'),
-    delete: getAdminOrSiteUser('reports'),
-    read: getAdminOrSiteUser('reports', ['manager', 'user', 'bot']),
-    update: getAdminOrSiteUser('reports'),
-  },
-  defaultPopulate: {
-    title: true,
-    slug: true,
+  labels: {
+    singular: 'Resource',
+    plural: 'Resources',
   },
   admin: {
+    group: 'Collections',
+    description: 'Resources and documents',
     defaultColumns: ['title', '_status', 'reviewReady'],
     meta: {
       title: 'Reports',
@@ -43,6 +39,16 @@ export const Reports: CollectionConfig<'reports'> = {
     },
     useAsTitle: 'title',
     hideAPIURL: true,
+  },
+  access: {
+    create: getAdminOrSiteUser('reports'),
+    delete: getAdminOrSiteUser('reports'),
+    read: getAdminOrSiteUser('reports', ['manager', 'user', 'bot']),
+    update: getAdminOrSiteUser('reports'),
+  },
+  defaultPopulate: {
+    title: true,
+    slug: true,
   },
   fields: [
     {

--- a/src/collections/Sites/index.ts
+++ b/src/collections/Sites/index.ts
@@ -12,17 +12,18 @@ import {
 
 export const Sites: CollectionConfig = {
   slug: 'sites',
+  admin: {
+    group: 'Site Configuration',
+    description: 'Multi-site management',
+    defaultColumns: ['name', 'updatedAt', 'createdAt'],
+    useAsTitle: 'name',
+    hidden: ({ user }) => !user?.isAdmin,
+  },
   access: {
     create: admin,
     delete: admin,
     read: adminOrAnySite,
     update: admin,
-  },
-  admin: {
-    defaultColumns: ['name', 'updatedAt', 'createdAt'],
-    useAsTitle: 'name',
-    hidden: ({ user }) => !user?.isAdmin,
-    group: 'Sites',
   },
   fields: [
     {

--- a/src/collections/Users/index.ts
+++ b/src/collections/Users/index.ts
@@ -19,17 +19,18 @@ const capitalize = (str: string) => {
 
 export const Users: CollectionConfig = {
   slug: 'users',
+  admin: {
+    group: 'User Management',
+    description: 'Team members and permissions',
+    defaultColumns: ['email', 'updatedAt', 'sites'],
+    useAsTitle: 'email',
+    hideAPIURL: true,
+  },
   access: {
     read: getAdminOrSiteUser('users'),
     update: getAdminOrSiteUser('users', ['manager']),
     delete: admin,
     create: getAdminOrSiteUser('users', ['manager']),
-  },
-  admin: {
-    defaultColumns: ['email', 'updatedAt', 'sites'],
-    useAsTitle: 'email',
-    hideAPIURL: true,
-    group: 'Information'
   },
   auth: {
     disableLocalStrategy: true,

--- a/src/globals/Menu.ts
+++ b/src/globals/Menu.ts
@@ -4,10 +4,15 @@ import { getAdminOrSiteUserGlobals } from '@/access/adminOrSite'
 
 export const Menu: GlobalConfig = {
   slug: 'menu',
+  label: 'Main Navigation',
   access: {
     read: getAdminOrSiteUserGlobals(['manager', 'user', 'bot']),
     update: getAdminOrSiteUserGlobals(),
     readVersions: getAdminOrSiteUserGlobals(),
+  },
+  admin: {
+    group: 'Site Configuration',
+    description: 'Navigation menu configuration',
   },
   fields: [
     {

--- a/src/globals/SiteConfig.ts
+++ b/src/globals/SiteConfig.ts
@@ -4,13 +4,15 @@ import { colorOptions } from '@/fields'
 
 export const SiteConfig: GlobalConfig = {
   slug: 'site-config',
+  label: 'Site Identity',
   access: {
     read: getAdminOrSiteUserGlobals(['manager', 'user', 'bot']),
     update: getAdminOrSiteUserGlobals(),
     readVersions: getAdminOrSiteUserGlobals(),
   },
   admin: {
-    group: 'Information',
+    group: 'Site Configuration',
+    description: 'Site settings and branding',
   },
   fields: [
     {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -70,15 +70,15 @@ export interface Config {
     posts: Post;
     events: Event;
     news: News;
-    media: Media;
-    'menu-site-collection': MenuSiteCollection;
     reports: Report;
+    leadership: Leadership;
     pages: Page;
     policies: Policy;
+    media: Media;
     categories: Category;
     sites: Site;
+    'menu-site-collection': MenuSiteCollection;
     'site-config-site-collection': SiteConfigSiteCollection;
-    leadership: Leadership;
     redirects: Redirect;
     forms: Form;
     'form-submissions': FormSubmission;
@@ -97,15 +97,15 @@ export interface Config {
     posts: PostsSelect<false> | PostsSelect<true>;
     events: EventsSelect<false> | EventsSelect<true>;
     news: NewsSelect<false> | NewsSelect<true>;
-    media: MediaSelect<false> | MediaSelect<true>;
-    'menu-site-collection': MenuSiteCollectionSelect<false> | MenuSiteCollectionSelect<true>;
     reports: ReportsSelect<false> | ReportsSelect<true>;
+    leadership: LeadershipSelect<false> | LeadershipSelect<true>;
     pages: PagesSelect<false> | PagesSelect<true>;
     policies: PoliciesSelect<false> | PoliciesSelect<true>;
+    media: MediaSelect<false> | MediaSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
     sites: SitesSelect<false> | SitesSelect<true>;
+    'menu-site-collection': MenuSiteCollectionSelect<false> | MenuSiteCollectionSelect<true>;
     'site-config-site-collection': SiteConfigSiteCollectionSelect<false> | SiteConfigSiteCollectionSelect<true>;
-    leadership: LeadershipSelect<false> | LeadershipSelect<true>;
     redirects: RedirectsSelect<false> | RedirectsSelect<true>;
     forms: FormsSelect<false> | FormsSelect<true>;
     'form-submissions': FormSubmissionsSelect<false> | FormSubmissionsSelect<true>;
@@ -154,6 +154,8 @@ export interface UserAuthOperations {
   };
 }
 /**
+ * Blog posts and articles
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "posts".
  */
@@ -196,6 +198,8 @@ export interface Post {
   _status?: ('draft' | 'published') | null;
 }
 /**
+ * Images, documents, and media files
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media".
  */
@@ -275,6 +279,8 @@ export interface Media {
   };
 }
 /**
+ * Multi-site management
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "sites".
  */
@@ -295,6 +301,8 @@ export interface Site {
   createdAt: string;
 }
 /**
+ * Team members and permissions
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
@@ -316,6 +324,8 @@ export interface User {
   apiKeyIndex?: string | null;
 }
 /**
+ * Content categories and tags
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "categories".
  */
@@ -338,6 +348,8 @@ export interface Category {
   createdAt: string;
 }
 /**
+ * Events and calendar items
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "events".
  */
@@ -379,6 +391,8 @@ export interface Event {
   _status?: ('draft' | 'published') | null;
 }
 /**
+ * News articles and announcements
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "news".
  */
@@ -413,6 +427,161 @@ export interface News {
   _status?: ('draft' | 'published') | null;
 }
 /**
+ * Resources and documents
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "reports".
+ */
+export interface Report {
+  id: number;
+  title: string;
+  excerpt?: string | null;
+  image?: (number | null) | Media;
+  reportFiles?:
+    | {
+        file?: (number | null) | Media;
+        id?: string | null;
+      }[]
+    | null;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  reportDate?: string | null;
+  categories?: (number | Category)[] | null;
+  site: number | Site;
+  content?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  reviewReady?: boolean | null;
+  publishedAt?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * Leadership team members
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "leadership".
+ */
+export interface Leadership {
+  id: number;
+  title: string;
+  jobTitle: string;
+  description?: string | null;
+  image?: (number | null) | Media;
+  /**
+   * Alternative text for the image for accessibility
+   */
+  imageAlt: string;
+  /**
+   * Detailed biography or description of the leadership member
+   */
+  content?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  site: number | Site;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * Individual website pages
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "pages".
+ */
+export interface Page {
+  id: number;
+  title: string;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  subtitle?: string | null;
+  label: string;
+  image?: (number | null) | Media;
+  content?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  site: number | Site;
+  reviewReady?: boolean | null;
+  publishedAt?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * Policies and procedures
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "policies".
+ */
+export interface Policy {
+  id: number;
+  title: string;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  label: string;
+  content?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  site: number | Site;
+  reviewReady?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * Navigation menu configuration
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "menu-site-collection".
  */
@@ -466,116 +635,8 @@ export interface MenuSiteCollection {
   _status?: ('draft' | 'published') | null;
 }
 /**
- * Manage single pages that are shown in the site.
+ * Site settings and branding
  *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "pages".
- */
-export interface Page {
-  id: number;
-  title: string;
-  slug?: string | null;
-  slugLock?: boolean | null;
-  subtitle?: string | null;
-  label: string;
-  image?: (number | null) | Media;
-  content?: {
-    root: {
-      type: string;
-      children: {
-        type: string;
-        version: number;
-        [k: string]: unknown;
-      }[];
-      direction: ('ltr' | 'rtl') | null;
-      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-      indent: number;
-      version: number;
-    };
-    [k: string]: unknown;
-  } | null;
-  site: number | Site;
-  reviewReady?: boolean | null;
-  publishedAt?: string | null;
-  updatedAt: string;
-  createdAt: string;
-  _status?: ('draft' | 'published') | null;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "reports".
- */
-export interface Report {
-  id: number;
-  title: string;
-  excerpt?: string | null;
-  image?: (number | null) | Media;
-  reportFiles?:
-    | {
-        file?: (number | null) | Media;
-        id?: string | null;
-      }[]
-    | null;
-  slug?: string | null;
-  slugLock?: boolean | null;
-  reportDate?: string | null;
-  categories?: (number | Category)[] | null;
-  site: number | Site;
-  content?: {
-    root: {
-      type: string;
-      children: {
-        type: string;
-        version: number;
-        [k: string]: unknown;
-      }[];
-      direction: ('ltr' | 'rtl') | null;
-      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-      indent: number;
-      version: number;
-    };
-    [k: string]: unknown;
-  } | null;
-  reviewReady?: boolean | null;
-  publishedAt?: string | null;
-  updatedAt: string;
-  createdAt: string;
-  _status?: ('draft' | 'published') | null;
-}
-/**
- * Manage policies that are shown in the site.
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "policies".
- */
-export interface Policy {
-  id: number;
-  title: string;
-  slug?: string | null;
-  slugLock?: boolean | null;
-  label: string;
-  content?: {
-    root: {
-      type: string;
-      children: {
-        type: string;
-        version: number;
-        [k: string]: unknown;
-      }[];
-      direction: ('ltr' | 'rtl') | null;
-      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-      indent: number;
-      version: number;
-    };
-    [k: string]: unknown;
-  } | null;
-  site: number | Site;
-  reviewReady?: boolean | null;
-  updatedAt: string;
-  createdAt: string;
-  _status?: ('draft' | 'published') | null;
-}
-/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "site-config-site-collection".
  */
@@ -702,45 +763,6 @@ export interface SiteConfigSiteCollection {
   favicon?: (number | null) | Media;
   logo?: (number | null) | Media;
   site: number | Site;
-  updatedAt: string;
-  createdAt: string;
-  _status?: ('draft' | 'published') | null;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "leadership".
- */
-export interface Leadership {
-  id: number;
-  title: string;
-  jobTitle: string;
-  description?: string | null;
-  image?: (number | null) | Media;
-  /**
-   * Alternative text for the image for accessibility
-   */
-  imageAlt: string;
-  /**
-   * Detailed biography or description of the leadership member
-   */
-  content?: {
-    root: {
-      type: string;
-      children: {
-        type: string;
-        version: number;
-        [k: string]: unknown;
-      }[];
-      direction: ('ltr' | 'rtl') | null;
-      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-      indent: number;
-      version: number;
-    };
-    [k: string]: unknown;
-  } | null;
-  site: number | Site;
-  slug?: string | null;
-  slugLock?: boolean | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -1007,16 +1029,12 @@ export interface PayloadLockedDocument {
         value: number | News;
       } | null)
     | ({
-        relationTo: 'media';
-        value: number | Media;
-      } | null)
-    | ({
-        relationTo: 'menu-site-collection';
-        value: number | MenuSiteCollection;
-      } | null)
-    | ({
         relationTo: 'reports';
         value: number | Report;
+      } | null)
+    | ({
+        relationTo: 'leadership';
+        value: number | Leadership;
       } | null)
     | ({
         relationTo: 'pages';
@@ -1027,6 +1045,10 @@ export interface PayloadLockedDocument {
         value: number | Policy;
       } | null)
     | ({
+        relationTo: 'media';
+        value: number | Media;
+      } | null)
+    | ({
         relationTo: 'categories';
         value: number | Category;
       } | null)
@@ -1035,12 +1057,12 @@ export interface PayloadLockedDocument {
         value: number | Site;
       } | null)
     | ({
-        relationTo: 'site-config-site-collection';
-        value: number | SiteConfigSiteCollection;
+        relationTo: 'menu-site-collection';
+        value: number | MenuSiteCollection;
       } | null)
     | ({
-        relationTo: 'leadership';
-        value: number | Leadership;
+        relationTo: 'site-config-site-collection';
+        value: number | SiteConfigSiteCollection;
       } | null)
     | ({
         relationTo: 'redirects';
@@ -1178,6 +1200,85 @@ export interface NewsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "reports_select".
+ */
+export interface ReportsSelect<T extends boolean = true> {
+  title?: T;
+  excerpt?: T;
+  image?: T;
+  reportFiles?:
+    | T
+    | {
+        file?: T;
+        id?: T;
+      };
+  slug?: T;
+  slugLock?: T;
+  reportDate?: T;
+  categories?: T;
+  site?: T;
+  content?: T;
+  reviewReady?: T;
+  publishedAt?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "leadership_select".
+ */
+export interface LeadershipSelect<T extends boolean = true> {
+  title?: T;
+  jobTitle?: T;
+  description?: T;
+  image?: T;
+  imageAlt?: T;
+  content?: T;
+  site?: T;
+  slug?: T;
+  slugLock?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "pages_select".
+ */
+export interface PagesSelect<T extends boolean = true> {
+  title?: T;
+  slug?: T;
+  slugLock?: T;
+  subtitle?: T;
+  label?: T;
+  image?: T;
+  content?: T;
+  site?: T;
+  reviewReady?: T;
+  publishedAt?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "policies_select".
+ */
+export interface PoliciesSelect<T extends boolean = true> {
+  title?: T;
+  slug?: T;
+  slugLock?: T;
+  label?: T;
+  content?: T;
+  site?: T;
+  reviewReady?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media_select".
  */
 export interface MediaSelect<T extends boolean = true> {
@@ -1272,6 +1373,42 @@ export interface MediaSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "categories_select".
+ */
+export interface CategoriesSelect<T extends boolean = true> {
+  title?: T;
+  slug?: T;
+  slugLock?: T;
+  site?: T;
+  parent?: T;
+  breadcrumbs?:
+    | T
+    | {
+        doc?: T;
+        url?: T;
+        label?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "sites_select".
+ */
+export interface SitesSelect<T extends boolean = true> {
+  name?: T;
+  initialManagerEmail?: T;
+  pagesOrg?: T;
+  pagesSiteId?: T;
+  orgId?: T;
+  bucket?: T;
+  users?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "menu-site-collection_select".
  */
 export interface MenuSiteCollectionSelect<T extends boolean = true> {
@@ -1329,103 +1466,6 @@ export interface MenuSiteCollectionSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "reports_select".
- */
-export interface ReportsSelect<T extends boolean = true> {
-  title?: T;
-  excerpt?: T;
-  image?: T;
-  reportFiles?:
-    | T
-    | {
-        file?: T;
-        id?: T;
-      };
-  slug?: T;
-  slugLock?: T;
-  reportDate?: T;
-  categories?: T;
-  site?: T;
-  content?: T;
-  reviewReady?: T;
-  publishedAt?: T;
-  updatedAt?: T;
-  createdAt?: T;
-  _status?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "pages_select".
- */
-export interface PagesSelect<T extends boolean = true> {
-  title?: T;
-  slug?: T;
-  slugLock?: T;
-  subtitle?: T;
-  label?: T;
-  image?: T;
-  content?: T;
-  site?: T;
-  reviewReady?: T;
-  publishedAt?: T;
-  updatedAt?: T;
-  createdAt?: T;
-  _status?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "policies_select".
- */
-export interface PoliciesSelect<T extends boolean = true> {
-  title?: T;
-  slug?: T;
-  slugLock?: T;
-  label?: T;
-  content?: T;
-  site?: T;
-  reviewReady?: T;
-  updatedAt?: T;
-  createdAt?: T;
-  _status?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "categories_select".
- */
-export interface CategoriesSelect<T extends boolean = true> {
-  title?: T;
-  slug?: T;
-  slugLock?: T;
-  site?: T;
-  parent?: T;
-  breadcrumbs?:
-    | T
-    | {
-        doc?: T;
-        url?: T;
-        label?: T;
-        id?: T;
-      };
-  updatedAt?: T;
-  createdAt?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "sites_select".
- */
-export interface SitesSelect<T extends boolean = true> {
-  name?: T;
-  initialManagerEmail?: T;
-  pagesOrg?: T;
-  pagesSiteId?: T;
-  orgId?: T;
-  bucket?: T;
-  users?: T;
-  updatedAt?: T;
-  createdAt?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "site-config-site-collection_select".
  */
 export interface SiteConfigSiteCollectionSelect<T extends boolean = true> {
@@ -1437,24 +1477,6 @@ export interface SiteConfigSiteCollectionSelect<T extends boolean = true> {
   favicon?: T;
   logo?: T;
   site?: T;
-  updatedAt?: T;
-  createdAt?: T;
-  _status?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "leadership_select".
- */
-export interface LeadershipSelect<T extends boolean = true> {
-  title?: T;
-  jobTitle?: T;
-  description?: T;
-  image?: T;
-  imageAlt?: T;
-  content?: T;
-  site?: T;
-  slug?: T;
-  slugLock?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
@@ -1705,6 +1727,8 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   createdAt?: T;
 }
 /**
+ * Site settings and branding
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "site-config".
  */
@@ -1835,6 +1859,8 @@ export interface SiteConfig {
   createdAt?: string | null;
 }
 /**
+ * Navigation menu configuration
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "menu".
  */

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -48,6 +48,44 @@ const config = {
       //   Logo: '/graphics/Logo/index.tsx#Logo',
       // },
     },
+    groups: [
+      {
+        label: 'Collections',
+        admin: {
+          description: 'Content collections',
+        },
+      },
+      {
+        label: 'Standalone Pages',
+        admin: {
+          description: 'Standalone pages and policies',
+        },
+      },
+      {
+        label: 'Global Assets',
+        admin: {
+          description: 'Media and categories',
+        },
+      },
+      {
+        label: 'Analytics',
+        admin: {
+          description: 'Analytics and reporting',
+        },
+      },
+      {
+        label: 'User Management',
+        admin: {
+          description: 'Team members and permissions',
+        },
+      },
+      {
+        label: 'Site Configuration',
+        admin: {
+          description: 'Site settings and configuration',
+        },
+      },
+    ],
     user: Users.slug,
     livePreview: {
       breakpoints: [
@@ -82,19 +120,24 @@ const config = {
     prodMigrations: migrations,
   }),
   collections: [
+    // Collections group
     Posts,
     Events,
     News,
-    Media,
-    MenuCollection,
     Reports,
+    Leadership,
+    // Standalone Pages group
     Pages,
     Policies,
+    // Global Assets group
+    Media,
     Categories,
+    // User Management group
     Users,
+    // Site Configuration group
     Sites,
+    MenuCollection,
     SiteConfigCollection,
-    Leadership,
   ],
   cors: [getServerSideURL()].filter(Boolean),
   globals: [SiteConfig, Menu],


### PR DESCRIPTION
Closes https://github.com/cloud-gov/pages-editor/issues/91

## Changes proposed in this pull request:

- Reorganize Payload dashboard admin page per designs/feedback

## Security considerations

None
