### PR TITLE
fix: Pages staging postfix deploy variable

### DIFF
--- a/.cloudgov/vars/pages-staging.yml
+++ b/.cloudgov/vars/pages-staging.yml
@@ -3,5 +3,5 @@ instances: 2
 env: staging
 log_level: verbose
 node_env: production
-postfix: -dev
+postfix: -staging
 route: publisher-staging.cloud.gov


### PR DESCRIPTION
Closes https://github.com/cloud-gov/pages-editor/issues/113

## Changes proposed in this pull request:

- Fixes the `postfix` var for staging deploys

## Security considerations

N/A