### PR TITLE
fix: Add our custom lexical editor to Home Page rich text

### DIFF
--- a/src/globals/HomePage.ts
+++ b/src/globals/HomePage.ts
@@ -1,5 +1,6 @@
 import type { GlobalConfig } from 'payload'
 import { getAdminOrSiteUserGlobals } from '@/access/adminOrSite'
+import { editor } from '@/utilities/editor'
 
 export const HomePage: GlobalConfig = {
   slug: 'home-page',
@@ -164,6 +165,7 @@ export const HomePage: GlobalConfig = {
               name: 'content',
               type: 'richText',
               label: 'Content',
+              editor,
             },
           ],
         },


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds our custom lexical editor to the site's HomePage global collection for content blocks

## Security considerations

None
