### PR TITLE
chore: Update site create and delete hooks preview deploy config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/ui": "^3.0.8",
         "autoprefixer": "^10.4.19",
+        "aws-sdk-client-mock": "^4.1.0",
         "copyfiles": "^2.4.1",
         "dotenv": "^16.4.7",
         "eslint": "^9",
@@ -6508,6 +6509,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
@@ -7627,6 +7676,23 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.0.tgz",
+      "integrity": "sha512-lqKG4X0fO3aJF7Bz590vuCkFt/inbDyL7FXaVjPEYO+LogMZ2fwSDUiP7bJvdYHaCgCQGNOPxquzSrrnVH3fGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -8866,6 +8932,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+      "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinon": "^17.0.3",
+        "sinon": "^18.0.1",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.10.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
@@ -9886,6 +9964,16 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -13347,6 +13435,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -14946,6 +15041,41 @@
         "@img/sharp-wasm32": "0.33.5",
         "@img/sharp-win32-ia32": "0.33.5",
         "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/node-fetch": {
@@ -17230,6 +17360,25 @@
       "integrity": "sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==",
       "license": "MIT"
     },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
@@ -18329,6 +18478,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/ui": "^3.0.8",
     "autoprefixer": "^10.4.19",
+    "aws-sdk-client-mock": "^4.1.0",
     "copyfiles": "^2.4.1",
     "dotenv": "^16.4.7",
     "eslint": "^9",

--- a/src/collections/Sites/hooks/index.test.ts
+++ b/src/collections/Sites/hooks/index.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect, beforeEach, vi, afterAll } from 'vitest'
+import { mockClient } from 'aws-sdk-client-mock'
+import {
+  S3Client,
+  CopyObjectCommand,
+  DeleteObjectCommand,
+  S3ServiceException,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3'
+import { beforeDeleteHook, saveInfoToS3 } from './index'
+import { test } from '@test/utils/test'
+import { create, update, find } from '@test/utils/localHelpers'
+import { Site } from '@/payload-types'
+
+const BUCKET_NAME = 'test-bucket'
+
+// Mock the S3 client
+const s3Mock = mockClient(S3Client)
+
+describe('beforeDeleteHook', () => {
+  test.scoped({ defaultUserAdmin: true })
+
+  beforeEach(async () => {
+    // Reset the mock before each test
+    s3Mock.reset()
+
+    // Set up environment variables for testing
+    vi.stubEnv('SITE_METADATA_BUCKET', BUCKET_NAME)
+    // Not 'test' so S3 operations run
+    vi.stubEnv('NODE_ENV', 'development')
+  })
+
+  afterAll(() => {
+    vi.stubEnv('NODE_ENV', 'test')
+  })
+
+  test('should successfully copy and delete S3 objects when site is deleted', async ({
+    payload,
+    tid,
+  }) => {
+    // Create a test site
+    const site = await create(payload, tid, {
+      collection: 'sites',
+      data: {
+        name: 'temp-site',
+        initialManagerEmail: 'test@gsa.gov',
+      },
+    })
+
+    const { slug } = site as Site
+
+    // Mock successful S3 responses
+    s3Mock.on(CopyObjectCommand).resolves({})
+    s3Mock.on(DeleteObjectCommand).resolves({})
+
+    // Create a mock request object
+    const mockReq = {
+      payload,
+      transactionID: tid,
+    } as any as any
+
+    // Call the hook
+    await beforeDeleteHook({ req: mockReq, id: site.id } as any)
+
+    // Verify that CopyObjectCommand was called with correct parameters
+    const copyCalls = s3Mock.commandCalls(CopyObjectCommand)
+    expect(copyCalls).toHaveLength(1)
+    expect(copyCalls[0].args[0].input).toEqual({
+      Bucket: BUCKET_NAME,
+      CopySource: `${BUCKET_NAME}/_sites/active/${slug}.json`,
+      Key: `_sites/deleted/${slug}.json`,
+    })
+
+    // Verify that DeleteObjectCommand was called with correct parameters
+    const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
+    expect(deleteCalls).toHaveLength(1)
+    expect(deleteCalls[0].args[0].input).toEqual({
+      Bucket: BUCKET_NAME,
+      Key: `_sites/active/${slug}.json`,
+    })
+  })
+
+  test('should handle CopyObjectCommand failure', async ({ payload, tid }) => {
+    // Create a test site
+    const site = await create(payload, tid, {
+      collection: 'sites',
+      data: {
+        name: 'test-site',
+        initialManagerEmail: 'test@gsa.gov',
+      },
+    })
+
+    // Mock CopyObjectCommand failure
+    const copyError = new S3ServiceException({
+      name: 'NoSuchKey',
+      message: 'The specified key does not exist.',
+      $fault: 'client',
+      $metadata: {},
+    })
+    s3Mock.on(CopyObjectCommand).rejects(copyError)
+
+    // Create a mock request object
+    const mockReq = {
+      payload,
+      transactionID: tid,
+    } as any
+
+    // Mock console.error to avoid noise in test output
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Call the hook - it should not throw but log the error
+    await beforeDeleteHook({ req: mockReq, id: site.id } as any)
+
+    // Verify that CopyObjectCommand was called
+    const copyCalls = s3Mock.commandCalls(CopyObjectCommand)
+    expect(copyCalls).toHaveLength(1)
+
+    // Verify that DeleteObjectCommand was not called due to the error
+    const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
+    expect(deleteCalls).toHaveLength(0)
+
+    // Verify that the error was logged
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Error from S3 while deleting object'),
+    )
+
+    consoleSpy.mockRestore()
+  })
+
+  test('should handle DeleteObjectCommand failure', async ({ payload, tid }) => {
+    // Create a test site
+    const site = await create(payload, tid, {
+      collection: 'sites',
+      data: {
+        name: 'test-site',
+        initialManagerEmail: 'test@gsa.gov',
+      },
+    })
+
+    // Mock successful CopyObjectCommand and failed DeleteObjectCommand
+    s3Mock.on(CopyObjectCommand).resolves({})
+    const deleteError = new S3ServiceException({
+      name: 'AccessDenied',
+      message: 'Access Denied',
+      $fault: 'client',
+      $metadata: {},
+    })
+    s3Mock.on(DeleteObjectCommand).rejects(deleteError)
+
+    // Create a mock request object
+    const mockReq = {
+      payload,
+      transactionID: tid,
+    } as any
+
+    // Mock console.error to avoid noise in test output
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Call the hook - it should not throw but log the error
+    await beforeDeleteHook({ req: mockReq, id: site.id } as any)
+
+    // Verify that both commands were called
+    const copyCalls = s3Mock.commandCalls(CopyObjectCommand)
+    expect(copyCalls).toHaveLength(1)
+
+    const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
+    expect(deleteCalls).toHaveLength(1)
+
+    // Verify that the error was logged
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Error from S3 while deleting object'),
+    )
+
+    consoleSpy.mockRestore()
+  })
+
+  test('should skip S3 operations when SITE_METADATA_BUCKET is not set', async ({
+    payload,
+    tid,
+  }) => {
+    // Unset the bucket environment variable
+    delete process.env.SITE_METADATA_BUCKET
+
+    // Create a test site
+    const site = await create(payload, tid, {
+      collection: 'sites',
+      data: {
+        name: 'test-site',
+        initialManagerEmail: 'test@gsa.gov',
+      },
+    })
+
+    // Create a mock request object
+    const mockReq = {
+      payload,
+      transactionID: tid,
+    } as any
+
+    // Call the hook
+    await beforeDeleteHook({ req: mockReq, id: site.id } as any)
+
+    // Verify that no S3 commands were called
+    const copyCalls = s3Mock.commandCalls(CopyObjectCommand)
+    expect(copyCalls).toHaveLength(0)
+
+    const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
+    expect(deleteCalls).toHaveLength(0)
+  })
+
+  test('should skip S3 operations when NODE_ENV is test', async ({ payload, tid }) => {
+    // Set NODE_ENV to test
+    vi.stubEnv('NODE_ENV', 'test')
+
+    // Create a test site
+    const site = await create(payload, tid, {
+      collection: 'sites',
+      data: {
+        name: 'test-site',
+        initialManagerEmail: 'test@gsa.gov',
+      },
+    })
+
+    // Create a mock request object
+    const mockReq = {
+      payload,
+      transactionID: tid,
+    } as any
+
+    // Call the hook
+    await beforeDeleteHook({ req: mockReq, id: site.id } as any)
+
+    // Verify that no S3 commands were called
+    const copyCalls = s3Mock.commandCalls(CopyObjectCommand)
+    expect(copyCalls).toHaveLength(0)
+
+    const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
+    expect(deleteCalls).toHaveLength(0)
+  })
+
+  test('should delete solo users when site is deleted', async ({ payload, tid }) => {
+    const soloUserEmail = 'test-solo-user@gsa.gov'
+    const multiSiteUserEmail = 'test-multi-site-user@gsa.gov'
+
+    const [site, anotherSite] = await Promise.all([
+      create(payload, tid, {
+        collection: 'sites',
+        data: {
+          name: 'test-site',
+          initialManagerEmail: soloUserEmail,
+        },
+      }),
+      create(payload, tid, {
+        collection: 'sites',
+        data: {
+          name: 'another-site',
+          initialManagerEmail: multiSiteUserEmail,
+        },
+      }),
+    ])
+
+    // Create a test user
+    const [multiSiteUser, soloUser] = await Promise.all([
+      find(payload, tid, {
+        collection: 'users',
+        limit: 1,
+        where: {
+          email: { equals: multiSiteUserEmail },
+        },
+      }),
+      find(payload, tid, {
+        collection: 'users',
+        limit: 1,
+        where: {
+          email: { equals: soloUserEmail },
+        },
+      }),
+    ])
+
+    await update(payload, tid, {
+      collection: 'users',
+      id: multiSiteUser.docs[0].id,
+      data: {
+        sites: [
+          {
+            site: site.id,
+            role: 'manager',
+          },
+          {
+            site: anotherSite.id,
+            role: 'manager',
+          },
+        ],
+      },
+    })
+
+    // Create a spy to monitor payload.delete calls
+    const deleteSpy = vi.spyOn(payload, 'delete')
+
+    // Mock successful S3 responses
+    s3Mock.on(CopyObjectCommand).resolves({})
+    s3Mock.on(DeleteObjectCommand).resolves({})
+
+    // Create a mock request object
+    const mockReq = {
+      payload,
+      transactionID: tid,
+    } as any
+
+    // Call the hook
+    await beforeDeleteHook({ req: mockReq, id: site.id } as any)
+
+    // Verify that payload.delete was called
+    expect(deleteSpy).toHaveBeenCalledWith({
+      collection: 'users',
+      where: {
+        id: {
+          in: expect.any(String), // The solo user IDs joined as a string
+        },
+      },
+      req: mockReq,
+    })
+    expect((deleteSpy.mock.calls[0][0].where.id as any)?.in).toContain(
+      soloUser.docs[0].id.toString(),
+    )
+    expect((deleteSpy.mock.calls[0][0].where.id as any)?.in).not.toContain(
+      multiSiteUser.docs[0].id.toString(),
+    )
+    // Clean up the spy
+    deleteSpy.mockRestore()
+  })
+})
+
+describe('saveInfoToS3', () => {
+  test.scoped({ defaultUserAdmin: true })
+
+  beforeEach(async () => {
+    // Reset the mock before each test
+    s3Mock.reset()
+
+    // Set up environment variables for testing
+    vi.stubEnv('SITE_METADATA_BUCKET', BUCKET_NAME)
+    // Not 'test' so S3 operations run
+    vi.stubEnv('NODE_ENV', 'development')
+  })
+
+  afterAll(() => {
+    vi.stubEnv('NODE_ENV', 'test')
+  })
+
+  test('should save site info to S3', async ({ payload, tid }) => {
+    // Create a test site
+    const site = await create(payload, tid, {
+      collection: 'sites',
+      data: {
+        name: 'test-site',
+        initialManagerEmail: 'test@gsa.gov',
+      },
+    })
+
+    const { slug } = site as Site
+
+    const mockReq = {
+      payload,
+      transactionID: tid,
+    } as any
+
+    // Call the hook
+    await saveInfoToS3({ req: mockReq, id: site.id } as any)
+
+    const bot = (
+      await payload.find({
+        collection: 'users',
+        limit: 1,
+        where: {
+          and: [{ 'sites.site.id': { equals: site.id } }, { 'sites.role': { equals: 'bot' } }],
+        },
+        req: { transactionID: tid },
+      })
+    ).docs[0]
+
+    // Verify that PutObjectCommand was called with correct parameters
+    const copyCalls = s3Mock.commandCalls(PutObjectCommand)
+    const calledArgs = copyCalls[0].args[0].input
+    expect(copyCalls).toHaveLength(1)
+    expect(calledArgs.Body).toEqual(JSON.stringify({ ...site, apiKey: bot.apiKey }))
+  })
+})


### PR DESCRIPTION
Related to https://github.com/cloud-gov/pages-site-gantry/issues/113

## Changes proposed in this pull request:

- Updates the site create and delete hooks to send the preview deploy configs to new bucket prefixes to identify created vs deleted sites
- The pages-site-gantry CI pipeline will use these configs to deploy or delete the preview app  

## Security considerations

None
