### PR TITLE
fix: set the collection slug to 'page-menus'

### DIFF
--- a/src/collections/PageMenus/index.ts
+++ b/src/collections/PageMenus/index.ts
@@ -12,10 +12,10 @@ export const PageMenus: CollectionConfig = {
     plural: 'Page Menus',
   },
   access: {
-    create: getAdminOrSiteUser('reports'),
-    delete: getAdminOrSiteUser('reports'),
-    read: getAdminOrSiteUser('reports', ['manager', 'user', 'bot']),
-    update: getAdminOrSiteUser('reports'),
+    create: getAdminOrSiteUser('page-menus'),
+    delete: getAdminOrSiteUser('page-menus'),
+    read: getAdminOrSiteUser('page-menus', ['manager', 'user', 'bot']),
+    update: getAdminOrSiteUser('page-menus'),
   },
   admin: {
     group: 'Site Configuration',


### PR DESCRIPTION
Closes #152 
## Changes proposed in this pull request:

- Revises the slug in the access array to use the PageMenu collection slug


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

There are no security implications
