### PR TITLE
fix: Limit CODEOWNERS only to Pages team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @cloud-gov/pages-ops @cloud-gov/platform-ops
+* @cloud-gov/pages-ops
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- This is a duplicate of PR #163 because I failed to use the magic "fix: " prefix and my attempts to amend history failed.

## Security considerations

SAFE. More restrictive CODEOWNERS
