### PR TITLE
feat: Add afterDelete hook for site to call delete webhook to Pages core

### DIFF
--- a/src/collections/Sites/hooks/index.ts
+++ b/src/collections/Sites/hooks/index.ts
@@ -2,6 +2,7 @@ import type {
   CollectionBeforeValidateHook,
   CollectionAfterChangeHook,
   CollectionBeforeDeleteHook,
+  CollectionAfterDeleteHook,
 } from 'payload'
 import { Site } from '@/payload-types'
 import { v4 as uuidv4 } from 'uuid'
@@ -78,6 +79,25 @@ export const createSiteBot: CollectionAfterChangeHook<Site> = async ({ doc, req,
     }
   }
   return doc
+}
+
+export const deleteSiteBot: CollectionAfterDeleteHook<Site> = async ({ doc }) => {
+  if (process.env.PAGES_URL) {
+    const payload = encryptObjectValues(
+      { siteId: doc.pagesSiteId },
+      process.env.PAGES_ENCRYPTION_KEY,
+    )
+
+    await fetch(`${process.env.PAGES_URL}/webhook/site`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+  }
+
+  return
 }
 
 export const createManager: CollectionAfterChangeHook<Site> = async ({ doc, req, operation }) => {

--- a/src/collections/Sites/index.ts
+++ b/src/collections/Sites/index.ts
@@ -7,6 +7,7 @@ import {
   createSiteBot,
   createSiteSinglePolicies,
   createSiteSinglePages,
+  deleteSiteBot,
   formatSiteSlug,
   saveInfoToS3,
 } from './hooks'
@@ -90,6 +91,7 @@ export const Sites: CollectionConfig = {
       saveInfoToS3,
     ],
     beforeDelete: [beforeDeleteHook],
+    afterDelete: [deleteSiteBot],
   },
   timestamps: true,
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1185,6 +1185,9 @@ export interface FooterSiteCollection {
   logos?:
     | {
         url: string;
+        /**
+         * The logo image to be displayed in the footer
+         */
         image?: (number | null) | Media;
         id?: string | null;
       }[]
@@ -3237,6 +3240,9 @@ export interface Footer {
   logos?:
     | {
         url: string;
+        /**
+         * The logo image to be displayed in the footer
+         */
         image?: (number | null) | Media;
         id?: string | null;
       }[]


### PR DESCRIPTION
Closes https://github.com/cloud-gov/pages-site-gantry/issues/113

Related to https://github.com/cloud-gov/pages-core/pull/4838

## Changes proposed in this pull request:
- Adds a afterDelete hook for Sites collection to send a DELETE request to Pages core to delete the related site infrastructure

## Security considerations

None
