### PR TITLE
fix: allow heading level selection in process list feature

### DIFF
--- a/src/blocks/ProcessList.ts
+++ b/src/blocks/ProcessList.ts
@@ -6,11 +6,36 @@ export const ProcessListBlock: Block = {
   labels: { singular: 'Process List', plural: 'Process Lists' },
   fields: [
     {
+      name: 'headingLevel',
+      type: 'select',
+      defaultValue: 'h4',
+      options: [
+        { label: 'Heading 2', value: 'h2' },
+        { label: 'Heading 3', value: 'h3' },
+        { label: 'Heading 4', value: 'h4' },
+        { label: 'Heading 5', value: 'h5' },
+        { label: 'Heading 6', value: 'h6' },
+      ],
+      admin: {
+        description:
+          'Pick the heading level that\'s one step down from your last heading (H4 is selected by default).',
+      },
+      required: true,
+    },
+    {
       name: 'items',
       type: 'array',
       admin: { initCollapsed: false },
       fields: [
-        { name: 'heading', type: 'text', required: true },
+       { 
+          name: 'heading',
+          type: 'text',
+          required: true,
+          admin: {
+            width: '75%',
+            description: 'Heading text',
+          }
+        },
         {
           name: 'body',
           type: 'richText',
@@ -19,7 +44,7 @@ export const ProcessListBlock: Block = {
               ...defaultFeatures,
             ]
           })
-        }
+        },
       ]
     }
   ]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Enables Process List feature in Rich Text editor to set an H(n) level for the heading
- Adds a heading level field

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

There are no security implications.
