### PR TITLE
feat: add an accordion feature type

### DIFF
--- a/src/blocks/Accordion.ts
+++ b/src/blocks/Accordion.ts
@@ -1,0 +1,51 @@
+import { lexicalEditor } from '@payloadcms/richtext-lexical';
+import { Block } from "payload";
+
+export const AccordionBlock: Block = {
+  slug: 'accordion',
+  labels: { singular: 'Accordion', plural: 'Accordions' },
+  fields: [
+    {
+      name: 'headingLevel',
+      type: 'select',
+      defaultValue: 'h4',
+      options: [
+        { label: 'Heading 2', value: 'h2' },
+        { label: 'Heading 3', value: 'h3' },
+        { label: 'Heading 4', value: 'h4' },
+        { label: 'Heading 5', value: 'h5' },
+        { label: 'Heading 6', value: 'h6' },
+      ],
+      admin: {
+        description:
+          'Pick the heading level that\'s one step down from your last heading (H4 is selected by default).',
+      },
+      required: true,
+    },
+    {
+      name: 'items',
+      type: 'array',
+      admin: { initCollapsed: false },
+      fields: [
+        { 
+          name: 'heading',
+          type: 'text',
+          required: true,
+          admin: {
+            description: 'Heading text',
+          }
+        },
+        {
+          name: 'content',
+          type: 'richText',
+          required: true,
+          editor: lexicalEditor({
+            features: ({ defaultFeatures }) => [
+              ...defaultFeatures,
+            ]
+          })
+        },
+      ]
+    }
+  ]
+}

--- a/src/utilities/editor.ts
+++ b/src/utilities/editor.ts
@@ -1,4 +1,5 @@
 // standardize our editor features
+import { AccordionBlock } from '@/blocks/Accordion'
 import { ProcessListBlock } from '@/blocks/ProcessList'
 import { 
   lexicalEditor,
@@ -13,7 +14,7 @@ export const editor = lexicalEditor({
     FixedToolbarFeature(),
     EXPERIMENTAL_TableFeature(),
     BlocksFeature({
-      blocks: [ProcessListBlock],
+      blocks: [ProcessListBlock, AccordionBlock],
     }),
   ],
 })


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds an accordion block type for the rich text editor
- Includes the block type in BlockFeatures array

Companion pages-site-gantry PR https://github.com/cloud-gov/pages-site-gantry/pull/160

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No security risks 