### PR TITLE
fix: All collection preview links to point to the correct url

### DIFF
--- a/src/collections/Alerts/index.ts
+++ b/src/collections/Alerts/index.ts
@@ -30,8 +30,8 @@ export const Alerts: CollectionConfig = {
     livePreview: {
       url: getGlobalPreviewUrl,
     },
-    preview: () => {
-      return `${process.env.PREVIEW_URL}`
+    preview: async({ req }) => {
+      return getGlobalPreviewUrl({ req })
     },
     useAsTitle: 'title',
     hideAPIURL: true,

--- a/src/collections/CustomCollectionPages/index.ts
+++ b/src/collections/CustomCollectionPages/index.ts
@@ -8,6 +8,7 @@ import { editor } from '@/utilities/editor'
 import { completeReview } from '@/hooks/completeReview'
 import { populateUpdatedBy } from '@/hooks/populateUpdatedBy'
 import { relatedItems } from '@/fields/relatedItems'
+import { getCustomCollectionLivePreview, getCustomCollectionPreview } from '@/utilities/previews'
 
 export const CustomCollectionPages: CollectionConfig = {
   slug: 'custom-collection-pages',
@@ -21,6 +22,10 @@ export const CustomCollectionPages: CollectionConfig = {
     defaultColumns: ['title', 'collectionConfig', 'slug', 'updatedAt', 'updatedBy', '_status'],
     useAsTitle: 'title',
     hideAPIURL: true,
+    livePreview: {
+      url: getCustomCollectionLivePreview,
+    },
+    preview: getCustomCollectionPreview
   },
   access: {
     create: getAdminOrSiteUser('custom-collection-pages'),

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -6,7 +6,7 @@ import { editor } from '@/utilities/editor'
 import { publish } from '@/hooks/publish'
 import { siteField } from '@/fields/relationships'
 import { completeReview } from '@/hooks/completeReview'
-import { getPagePreviewUrl } from '@/utilities/previews'
+import { getAdminCollectionPreview, getPagePreviewUrl } from '@/utilities/previews'
 
 export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
@@ -17,10 +17,7 @@ export const Pages: CollectionConfig<'pages'> = {
     livePreview: {
       url: getPagePreviewUrl,
     },
-    preview: (data) => {
-      // TODO: fix per above
-      return `${process.env.PREVIEW_URL}/${data.path}`
-    },
+    preview: getAdminCollectionPreview('pages', false),
     useAsTitle: 'title',
     hideAPIURL: true,
   },

--- a/src/collections/Reports/index.ts
+++ b/src/collections/Reports/index.ts
@@ -5,7 +5,7 @@ import { getAdminOrSiteUser } from '@/access/adminOrSite'
 import { addSite } from '@/hooks/addSite'
 import { publish } from '@/hooks/publish'
 import { editor } from '@/utilities/editor'
-import { getCollectionPreviewUrl } from '@/utilities/previews'
+import { getAdminCollectionPreview, getCollectionPreviewUrl } from '@/utilities/previews'
 import { completeReview } from '@/hooks/completeReview'
 import { populateUpdatedBy } from '@/hooks/populateUpdatedBy'
 import { relatedItems } from '@/fields/relatedItems'
@@ -27,10 +27,7 @@ export const Reports: CollectionConfig = {
     livePreview: {
       url: getCollectionPreviewUrl('reports'),
     },
-    preview: (data) => {
-      // TODO: fix per above
-      return `${process.env.PREVIEW_URL}/reports/${data.slug}`
-    },
+    preview: getAdminCollectionPreview('reports'),
     useAsTitle: 'title',
     hideAPIURL: true,
   },
@@ -107,7 +104,7 @@ export const Reports: CollectionConfig = {
         components: {
           Cell: 'src/components/UpdatedByCellData/',
         },
-      }
+      },
     },
     {
       name: 'publishedAt',

--- a/src/collections/Resources/index.ts
+++ b/src/collections/Resources/index.ts
@@ -1,5 +1,5 @@
 import type { CollectionConfig } from 'payload'
-import { getCollectionPreviewUrl } from '@/utilities/previews'
+import { getAdminCollectionPreview, getCollectionPreviewUrl } from '@/utilities/previews'
 import { categoriesField, siteField } from '@/fields/relationships'
 import { slugField } from '@/fields/slug'
 import { getAdminOrSiteUser } from '@/access/adminOrSite'
@@ -27,10 +27,7 @@ export const Resources: CollectionConfig = {
     livePreview: {
       url: getCollectionPreviewUrl('resources'),
     },
-    preview: async (doc, { req }) => {
-      const build = getCollectionPreviewUrl('posts')
-      return build( { data: doc, req })
-    },
+    preview: getAdminCollectionPreview('resources'),
     useAsTitle: 'title',
     hideAPIURL: true,
   },


### PR DESCRIPTION
Closes #77 
Closes https://github.com/cloud-gov/pages-editor/issues/136

## Changes proposed in this pull request:
- Unifies and verifies all collection items use the correct preview urls
- Adds a preview helper for custom collection pages

## Security considerations

None
