### PR TITLE
feat: create user roles and permissions page

### DIFF
--- a/public/assets/images/add-white.svg
+++ b/public/assets/images/add-white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#ffffff" d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>

--- a/public/assets/images/remove-white.svg
+++ b/public/assets/images/remove-white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="#ffffff" d="M19 13H5v-2h14v2z"/></svg>

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -37,10 +37,12 @@ import { ReindexButton as ReindexButton_aead06e4cbf6b2620c5c51c9ab283634 } from 
 import { default as default_0c3317dc490d2187d9715694656ec3d3 } from '@/components/SiteCell'
 import { default as default_2e6cf1b1b850543a1bd5771a5b86ee4d } from '@/components/SiteRowLabel'
 import { default as default_32d7f490396abda7b466903585904485 } from '@/components/RemoveUser'
+import { default as default_7ce813284ffa92867fd9fdc508e13505 } from 'src/components/UserCollectionDescription'
 import { default as default_fedc587b86d65a6c9503093fbd9e9e2f } from '@/components/CustomPublishButton'
 import { default as default_8a7ab0eb7ab5c511aba12e68480bfe5e } from '@/components/BeforeLogin'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 import { default as default_6d0fe59af291eda0374bdc5d5f9a5829 } from '@/components/CustomDashboard'
+import { default as default_7bac276e3812125fd6b97470a9f2783d } from '@/components/UserRolesAndPermissions'
 
 export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
@@ -82,8 +84,10 @@ export const importMap = {
   "@/components/SiteCell#default": default_0c3317dc490d2187d9715694656ec3d3,
   "@/components/SiteRowLabel#default": default_2e6cf1b1b850543a1bd5771a5b86ee4d,
   "@/components/RemoveUser#default": default_32d7f490396abda7b466903585904485,
+  "src/components/UserCollectionDescription#default": default_7ce813284ffa92867fd9fdc508e13505,
   "@/components/CustomPublishButton#default": default_fedc587b86d65a6c9503093fbd9e9e2f,
   "@/components/BeforeLogin#default": default_8a7ab0eb7ab5c511aba12e68480bfe5e,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24,
-  "@/components/CustomDashboard#default": default_6d0fe59af291eda0374bdc5d5f9a5829
+  "@/components/CustomDashboard#default": default_6d0fe59af291eda0374bdc5d5f9a5829,
+  "@/components/UserRolesAndPermissions#default": default_7bac276e3812125fd6b97470a9f2783d
 }

--- a/src/app/(payload)/custom.scss
+++ b/src/app/(payload)/custom.scss
@@ -17,6 +17,9 @@
 @forward "usa-skipnav";
 @forward "usa-summary-box";
 @forward "uswds-utilities";
+@forward "usa-table";
+@forward "usa-accordion";
+@forward "usa-in-page-navigation";
 
 // Import USWDS variables early so they're available for custom styles
 @import "../styles/uswds-variables.scss";
@@ -451,4 +454,49 @@ button {
 
 .list-header__actions {
     margin-left: var(--spacing-4);
+}
+
+// In page nav container
+// Roles and Permissions page
+
+.usa-in-page-nav-container {
+  position: relative;
+  max-width: 75rem;
+  margin-left: auto;
+  margin-right: auto;
+  main {
+    max-width: 55rem;
+    h2, h4 {
+        font-family: inherit;
+    }
+    .usa-prose > ul.margin-top-1 {
+        margin-top: .5rem;
+        li {
+            line-height: 1;
+        }
+    }
+    .usa-prose > .usa-table-container--scrollable td {
+        vertical-align: top;
+    }
+  }
+}
+
+.usa-table--borderless thead.bg-base-lighter th {
+    background-color: #dfe1e2;
+}
+
+.usa-accordion__button.bg-primary {
+    background-color: #005ea2;
+    color: #ffffff;
+    background-image: url(/assets/images/remove-white.svg), linear-gradient(transparent, transparent);
+    &:hover {
+        background-color: #1a4480;
+    }
+}
+
+.usa-accordion__button.bg-primary[aria-expanded=false] {
+    background-image: url(/assets/images/add-white.svg), linear-gradient(transparent, transparent);
+    &:hover {
+        background-color: #1a4480;
+    }
 }

--- a/src/collections/Users/index.ts
+++ b/src/collections/Users/index.ts
@@ -21,6 +21,9 @@ export const Users: CollectionConfig = {
   slug: 'users',
   admin: {
     group: 'User Management',
+    components: {
+      Description: 'src/components/UserCollectionDescription',
+    },
     description: 'Manage who can access and edit the site, including roles and permissions.',
     defaultColumns: ['email', 'updatedAt', 'sites'],
     useAsTitle: 'email',

--- a/src/components/CustomDashboard/index.tsx
+++ b/src/components/CustomDashboard/index.tsx
@@ -100,6 +100,27 @@ const CustomDashboard: React.FC = async (props: { payload: BasePayload }) => {
     groupedItems[groupKey].push(item)
   })
 
+  const usersGroup = collections.find(c => c.slug === 'users')?.group || 'User Management'
+
+  const rolesAndPermissionsPage = {
+    slug: 'sites-roles-and-permissions',
+    label: 'Site Roles and Permissions',
+    description: 'Documentation on roles and permissions.',
+    group: typeof usersGroup === 'string' ? usersGroup : 'User Management',
+    href: '/admin/sites-roles-and-permissions',
+  }
+
+  if (!groupedItems[rolesAndPermissionsPage.group]) {
+    groupedItems[rolesAndPermissionsPage.group] = []
+  }
+
+  const usersIdx = groupedItems[rolesAndPermissionsPage.group].findIndex(i => i.slug === 'users')
+  if(usersIdx >= 0) {
+    groupedItems[rolesAndPermissionsPage.group].splice(usersIdx + 1, 0, rolesAndPermissionsPage as any)
+  } else {
+    groupedItems[rolesAndPermissionsPage.group].push(rolesAndPermissionsPage as any)
+  }
+
   // Define the order of groups
   const groupOrder = [
     'Content Collection',

--- a/src/components/UserCollectionDescription/index.tsx
+++ b/src/components/UserCollectionDescription/index.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+const UserCollectionDescription = () => {
+  return (
+    <>
+      <p>Manage who can access and edit the site, including roles and permissions.</p>
+      <p>Learn about roles and permissions <Link style={{textDecoration: "underline"}} href="/admin/sites-roles-and-permissions">here</Link>.</p>
+    </>
+  )
+}
+
+export default UserCollectionDescription;

--- a/src/components/UserRolesAndPermissions/SetStepNav.client.tsx
+++ b/src/components/UserRolesAndPermissions/SetStepNav.client.tsx
@@ -1,0 +1,34 @@
+"use client";
+// ref https://github.com/payloadcms/payload/issues/12344#issuecomment-2867110662
+// workaround for Breadcrumbs not working when using DefaultTemplate
+import { useEffect } from "react";
+import { useStepNav } from "@payloadcms/ui";
+
+export function SetStepNav() {
+  const { setStepNav } = useStepNav();
+
+  useEffect(() => {
+    // Define your breadcrumb path. The first entry should be the "home"/dashboard.
+    // Subsequent entries represent the current custom view trail.
+    setStepNav([
+      {
+        label: "Sites Roles and Permissions",
+        url: "/admin/sites-roles-and-permissions", // your custom view route
+      },
+    ]);
+
+    // Optional: on unmount, clear or reset to dashboard-only
+    return () => {
+      try {
+        setStepNav([
+          { label: "Dashboard", url: "/admin" },
+        ]);
+      } catch {
+        /* no-op */
+      }
+    };
+  }, [setStepNav]);
+
+  // This component only sets step nav; it renders nothing.
+  return null;
+}

--- a/src/components/UserRolesAndPermissions/USWDSInPageNavInit.client.tsx
+++ b/src/components/UserRolesAndPermissions/USWDSInPageNavInit.client.tsx
@@ -1,0 +1,90 @@
+
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * USWDSInit — Client-only initializer for:
+ *  - In-page navigation
+ *  - Accordion
+ *
+ * It dynamically imports USWDS JS and initializes components on the document.
+ * Safe for Next.js App Router: nothing runs during SSR.
+ */
+export function USWDSInit() {
+  useEffect(() => {
+    let inPageNav: any | undefined;
+       let accordion: any | undefined;
+
+    let mounted = true;
+
+    (async () => {
+      try {
+        // In-page navigation
+        const inPageNavMod = await import("@uswds/uswds/js/usa-in-page-navigation");
+        inPageNav = inPageNavMod?.default ?? inPageNavMod;
+
+        // Accordion
+        const accordionMod = await import("@uswds/uswds/js/usa-accordion");
+        accordion = accordionMod?.default ?? accordionMod;
+
+        if (mounted) {
+          // Initialize both against the document
+          inPageNav?.on(document.body);
+          accordion?.on(document.body);
+
+          // Optional: if headings are dynamically injected/updated,
+          // re-init the in-page nav when <main> headings change.
+          const main = document.querySelector("main");
+          if (main) {
+            const observer = new MutationObserver(() => {
+              try {
+                // Re-run to rebuild TOC (guarding against double init)
+                inPageNav?.off(document.body);
+                inPageNav?.on(document.body);
+              } catch {
+                /* no-op */
+              }
+            });
+
+            observer.observe(main, {
+              subtree: true,
+              childList: true,
+              characterData: true,
+            });
+
+            // Clean up the observer on unmount
+            (USWDSInit as any)._observer = observer;
+          }
+        }
+      } catch {
+        // Silence errors to avoid noisy logs during dev hot reload
+      }
+    })();
+
+    return () => {
+      mounted = false;
+      try {
+        // Disconnect the mutation observer if we created one
+        const observer = (USWDSInit as any)._observer as MutationObserver | undefined;
+        observer?.disconnect();
+      } catch {
+        /* no-op */
+      }
+
+      try {
+        inPageNav?.off(document.body);
+      } catch {
+        /* no-op */
+      }
+
+      try {
+        accordion?.off(document.body);
+      } catch {
+        /* no-op */
+      }
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/UserRolesAndPermissions/index.tsx
+++ b/src/components/UserRolesAndPermissions/index.tsx
@@ -1,0 +1,681 @@
+import React from "react";
+import type { AdminViewServerProps } from "payload";
+import { DefaultTemplate } from "@payloadcms/next/templates";
+import { Gutter } from "@payloadcms/ui";
+import Link from "next/link";
+import { Check, X } from "lucide-react";
+import { USWDSInit } from "./USWDSInPageNavInit.client";
+import { SetStepNav } from "./SetStepNav.client";
+import { redirect } from "next/navigation";
+
+/**
+* User Roles & Permissions — Custom Root View (Server Component)
+* Wrapped in DefaultTemplate so the admin chrome (header, sidebar, breadcrumbs) renders.
+* The in-page nav aside + headings in <main> are picked up by USWDS JS initialized by the client component.
+*/
+export default function UserRolesAndPermissions(props: AdminViewServerProps) {
+ const { initPageResult, params, searchParams } = props;
+ const { req, permissions, locale, visibleEntities } = initPageResult;
+ const user = req.user
+
+ if(!user) {
+  // redirect to login if not logged in
+  redirect(`/admin/login`)
+ }
+
+ return (
+  <DefaultTemplate
+   i18n={req.i18n}
+   locale={locale}
+   params={params}
+   payload={req.payload}
+   permissions={permissions}
+   searchParams={searchParams}
+   user={user || undefined}
+   visibleEntities={visibleEntities}
+  >
+   {/* Initialize USWDS In-page nav, accordion on the client and fix breadcrumbs */}
+   <USWDSInit />
+   <SetStepNav />
+
+   {/* Main content */}
+   <Gutter>
+    {/* In-page nav + content layout */}
+    <div className="usa-in-page-nav-container">
+      {/* USWDS JS auto-populates this aside based on headings inside <main> */}
+      <aside
+        className="usa-in-page-nav"
+        data-title-text="On this page"
+        data-title-heading-level="h4"
+        data-scroll-offset="0"
+        data-root-margin="0px 0px 0px 0px"
+        data-threshold="1"
+      />
+    <main id="main-content">
+      <section className="usa-section section section--white align-left">
+        <div className="grid-container">
+          <div className="grid-row">
+            <div className="tablet:grid-col-10">
+              <div className="section__container">
+                <div className="section__slot">
+                  <div className="flex-column margin-bottom-5">
+                    <h1>Cloud.gov Publisher Sites Roles and Permissions</h1>
+                    <p className="margin-top-2">Documentation on roles and permissions. <Link href="/admin/collections/users?limit=10">Manage who can access and edit the site here.</Link></p>
+                  </div>
+                  <section className="usa-prose">
+                    <h2 className="source-sans-pro">Cloud.gov Publisher (Multi-Tenant) Roles</h2>
+                    <p>When you add a user to a site, you assign them a <strong>role</strong>. The role determines which
+                    actions they can perform on content, users, and automation workflows within that site.</p>
+                    <p>If a user has roles across multiple sites, their permissions apply <strong>per site</strong>. The same
+                    person may be a <strong>Manager</strong> on one site and a <strong>User</strong> on another.</p>
+                    <p><strong>System Administrators</strong> (Cloud.gov Page&apos;s Engineers/Operators) have global access to
+                    all sites and are not governed by site-level role permissions.</p>
+
+                    <h2>Available Roles</h2>
+                    <div className="usa-table-container--scrollable">
+                      <table className="usa-table usa-table--borderless">
+                        <thead className="bg-base-lighter">
+                          <tr>
+                            <th scope="col">Role</th>
+                            <th scope="col">Description</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>Manager</td>
+                            <td>Full control of site content and user management.</td>
+                          </tr>
+                          <tr>
+                            <td>User</td>
+                            <td>Contributor with limited publishing rights.</td>
+                          </tr>
+                          <tr>
+                            <td>Bot</td>
+                            <td>System-generated automation account for CI/CD and maintenance.</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <p><strong>Notes</strong></p>
+                    <ul>
+                      <li>
+                        A <strong>User</strong> has the least permissions, while a <strong>Manager</strong> has the most.
+                      </li>
+                      <li>
+                        <strong>Bots</strong> are restricted to programmatic actions through the API.
+                      </li>
+                    </ul>
+
+                    <h2>Role Definitions</h2>
+                    <div className="usa-accordion usa-accordion--multiselectable" data-allow-multiple>
+                      <h4 className="usa-accordion__heading">
+                        <button
+                          type="button"
+                          className="usa-accordion__button bg-primary"
+                          aria-expanded="true"
+                          aria-controls="a1"
+                        >
+                          Manager (Site Manager)
+                        </button>
+                      </h4>
+                      <div id="a1" className="usa-accordion__content usa-prose">
+                        <h4>
+                          Description
+                        </h4>
+                        <p className="margin-top-1">
+                          Manages all content and users within a single site. Has full CRUD and publishing rights
+                          but cannot modify system-level or infrastructure settings of the Cloud.gov Publisher.
+                        </p>
+                        <h4>
+                          Capabilities
+                        </h4>
+                        <ul className="margin-top-1">
+                          <li>Create, edit, and publish content.</li>
+                          <li>Manage site users and assign roles.</li>
+                          <li>Approve content from other users.</li>
+                          <li>Edit site configuration.</li>
+                        </ul>
+                      </div>
+                      <h4 className="usa-accordion__heading">
+                        <button
+                          type="button"
+                          className="usa-accordion__button bg-primary"
+                          aria-expanded="false"
+                          aria-controls="a2"
+                        >
+                          User
+                        </button>
+                      </h4>
+                      <div id="a2" className="usa-accordion__content usa-prose">
+                        <h4>
+                          Description
+                        </h4>
+                        <p className="margin-top-1">
+                          Contributor role with limited permissions, can create and edit drafts but cannot
+                          publish or manage users.
+                        </p>
+                        <h4>
+                          Capabilities
+                        </h4>
+                        <ul className="margin-top-1">
+                          <li>Create and update draft content.</li>
+                          <li>Collaborate with Managers for publishing.</li>
+                          <li>Maintain their own profile and access dashboard.</li>
+                        </ul>
+                      </div>
+                      <h4 className="usa-accordion__heading">
+                        <button
+                          type="button"
+                          className="usa-accordion__button bg-primary"
+                          aria-expanded="false"
+                          aria-controls="a3"
+                        >
+                          Bot
+                        </button>
+                      </h4>
+                      <div id="a3" className="usa-accordion__content usa-prose">
+                        <h4>
+                          Description
+                        </h4>
+                        <p className="margin-top-1">
+                          The bot role has read only access. It cannot update or delete content.
+                        </p>
+                        <h4>
+                          Capabilities
+                        </h4>
+                        <ul className="margin-top-1">
+                          <li>Run automated jobs or deploy published sites.</li>
+                        </ul>
+                      </div>
+                    </div>
+
+                    <h2>Feature Permission Matrix</h2>
+                    <div className="usa-table-container--scrollable">
+                      <table className="usa-table usa-table--borderless">
+                        <thead className="bg-base-lighter">
+                          <tr>
+                            <th>Feature Area</th>
+                            <th>Action</th>
+                            <th>User</th>
+                            <th>Manager</th>
+                            <th>Bot</th>
+                            <th>Notes</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td rowSpan={5}>Content Management</td>
+                            <td>Create Drafts</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Users can create content;<br/>
+                            Managers can edit any content</td>
+                          </tr>
+                          <tr>
+                            <td>Read drafts</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td>All roles can read site content</td>
+                          </tr>
+                          <tr>
+                            <td>Update drafts</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Managers can update<br/>published content; Users only drafts</td>
+                          </tr>
+                          <tr>
+                            <td>Delete content</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Managers can delete content</td>
+                          </tr>
+                          <tr>
+                            <td>Publish content</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Only Managers can publish</td>
+                          </tr>
+                          <tr>
+                            <td rowSpan={3}>User Management</td>
+                            <td>View site users</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Only Managers can view and manage users</td>
+                          </tr>
+                          <tr>
+                            <td>Add new users</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Restricted to Managers</td>
+                          </tr>
+                          <tr>
+                            <td>Edit or remove users</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Managers cannot assign Bot or Admin roles</td>
+                          </tr>
+                          <tr>
+                            <td>Role Management</td>
+                            <td>Assign roles</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Managers can assign User or Manager only</td>
+                          </tr>
+                          <tr>
+                            <td rowSpan={2}>Site Access</td>
+                            <td>Access site dashboard</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Managers and Users can access the site dashboard</td>
+                          </tr>
+                          <tr>
+                            <td>Modify site configuration</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Restricted to Managers</td>
+                          </tr>
+                          <tr>
+                            <td rowSpan={2}>Automation / API</td>
+                            <td>Access via API key</td>
+                            <td><X /></td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td>API authentication only</td>
+                          </tr>
+                          <tr>
+                            <td>Trigger publish or deploy</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Used for scheduled releases</td>
+                          </tr>
+                          <tr>
+                            <td rowSpan={2}>UI Access</td>
+                            <td>Login to web app</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Bots cannot log in</td>
+                          </tr>
+                          <tr>
+                            <td>Manage personal profile</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                            <td>Not applicable for Bots</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+
+                    <h2>Permissions by Resource</h2>
+                    <p>The following sections provide permission summaries for each key resource area.</p>
+                    <h3><strong>Site Content</strong></h3>
+                    <div className="usa-table-container--scrollable">
+                      <table className="usa-table usa-table--borderless width-full">
+                        <thead className="bg-base-lighter">
+                          <tr>
+                            <th>Action</th>
+                            <th>User</th>
+                            <th>Manager</th>
+                            <th>Bot</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>Create content</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Edit draft content</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Edit published content</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Delete content</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Publish or unpublish content</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>View all content</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <p><strong>Notes</strong></p>
+                    <ul>
+                      <li>Managers can override or delete any content.</li>
+                      <li>Users can only edit drafts they created.</li>
+                    </ul>
+
+                    <h3><strong>Site User and Role Management</strong></h3>
+                    <div className="usa-table-container--scrollable">
+                      <table className="usa-table usa-table--borderless width-full">
+                        <thead className="bg-base-lighter">
+                          <tr>
+                            <th>Action</th>
+                            <th>User</th>
+                            <th>Manager</th>
+                            <th>Bot</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>View site users</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Invite or add users</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Edit or remove users</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Assign user roles</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Assign Bot role</td>
+                            <td><X /></td>
+                            <td><X /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Assign System Admin role</td>
+                            <td><X /></td>
+                            <td><X /></td>
+                            <td><X /></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <p><strong>Notes</strong></p>
+                    <ul>
+                      <li>Managers can assign only User and Manager roles.</li>
+                      <li>Bots and Users cannot modify user lists or roles.</li>
+                    </ul>
+
+                    <h3><strong>Site Access and Configuration</strong></h3>
+                    <div className="usa-table-container--scrollable">
+                      <table className="usa-table usa-table--borderless width-full">
+                        <thead className="bg-base-lighter">
+                          <tr>
+                            <th>Action</th>
+                            <th>User</th>
+                            <th>Manager</th>
+                            <th>Bot</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>Access dashboard</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Modify site configuration (Change template)</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Access other sites</td>
+                            <td><X /></td>
+                            <td><X /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Manage site integrations</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <p><strong>Notes</strong></p>
+                    <ul>
+                      <li>Configuration edits are site-scoped; Managers cannot modify other sites.</li>
+                      <li>Bots are isolated to API actions.</li>
+                    </ul>
+
+                    <h3><strong>Automation and API Permissions</strong></h3>
+                    <div className="usa-table-container--scrollable">
+                      <table className="usa-table usa-table--borderless width-full">
+                        <thead className="bg-base-lighter">
+                          <tr>
+                            <th>Action</th>
+                            <th>User</th>
+                            <th>Manager</th>
+                            <th>Bot</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>Access API</td>
+                            <td><X /></td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                          </tr>
+                          <tr>
+                            <td>Create or modify content via API</td>
+                            <td><X /></td>
+                            <td><X /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Trigger CI/CD workflows</td>
+                            <td><X /></td>
+                            <td><X /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Manage API keys</td>
+                            <td><X /></td>
+                            <td><X /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Run scheduled publish tasks</td>
+                            <td><X /></td>
+                            <td><X /></td>
+                            <td><X /></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <p><strong>Notes</strong></p>
+                    <ul>
+                      <li>Bots authenticate using API keys.</li>
+                      <li>API keys are managed at the system level by administrators.</li>
+                    </ul>
+
+                    <h3><strong>UI and Authentication</strong></h3>
+                    <div className="usa-table-container--scrollable">
+                      <table className="usa-table usa-table--borderless width-full">
+                        <thead className="bg-base-lighter">
+                          <tr>
+                            <th>Action</th>
+                            <th>User</th>
+                            <th>Manager</th>
+                            <th>Bot</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>Log in to web interface</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Manage personal profile</td>
+                            <td><Check /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Access site admin panel</td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                            <td><X /></td>
+                          </tr>
+                          <tr>
+                            <td>Use system credentials</td>
+                            <td><X /></td>
+                            <td><X /></td>
+                            <td><Check /></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <p><strong>Notes</strong></p>
+                    <ul>
+                      <li>Bots do not have UI access.</li>
+                      <li>Managers access site admin panels for content and user management.</li>
+                    </ul>
+
+                    <h2>Example: Authorization Table</h2>
+                    <div className="usa-table-container--scrollable">
+                      <table className="usa-table usa-table--borderless width-full">
+                        <thead className="bg-base-lighter">
+                          <tr>
+                            <th>Site_id</th>
+                            <th>Role</th>
+                            <th>Resource</th>
+                            <th>Action</th>
+                            <th>Allowed</th>
+                            <th>Source</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>101</td>
+                            <td>manager</td>
+                            <td>content</td>
+                            <td>create</td>
+                            <td><Check /></td>
+                            <td>site role</td>
+                          </tr>
+                          <tr>
+                            <td>101</td>
+                            <td>manager</td>
+                            <td>content</td>
+                            <td>publish</td>
+                            <td><Check /></td>
+                            <td>site role</td>
+                          </tr>
+                          <tr>
+                            <td>101</td>
+                            <td>manager</td>
+                            <td>users</td>
+                            <td>manage</td>
+                            <td><Check /></td>
+                            <td>site role</td>
+                          </tr>
+                          <tr>
+                            <td>101</td>
+                            <td>user</td>
+                            <td>content</td>
+                            <td>create</td>
+                            <td><Check /></td>
+                            <td>site role</td>
+                          </tr>
+                          <tr>
+                            <td>101</td>
+                            <td>user</td>
+                            <td>content</td>
+                            <td>publish</td>
+                            <td><X /></td>
+                            <td>site role</td>
+                          </tr>
+                          <tr>
+                            <td>101</td>
+                            <td>bot</td>
+                            <td>api</td>
+                            <td>access</td>
+                            <td><X /></td>
+                            <td>API key</td>
+                          </tr>
+                          <tr>
+                            <td>101</td>
+                            <td>bot</td>
+                            <td>content</td>
+                            <td>publish</td>
+                            <td><Check /></td>
+                            <td>automation</td>
+                          </tr>
+                          <tr>
+                            <td>102</td>
+                            <td>manager</td>
+                            <td>content</td>
+                            <td>publish</td>
+                            <td><Check /></td>
+                            <td>site role</td>
+                          </tr>
+                          <tr>
+                            <td>102</td>
+                            <td>user</td>
+                            <td>content</td>
+                            <td>edit</td>
+                            <td><Check /></td>
+                            <td>site role</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+
+                  </section>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+     </main>
+    </div>
+   </Gutter>
+  </DefaultTemplate>
+ );
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -3,7 +3,7 @@ import { postgresAdapter } from '@payloadcms/db-postgres'
 
 import sharp from 'sharp' // sharp-import
 import path from 'path'
-import { buildConfig } from 'payload'
+import { AdminViewConfig, buildConfig } from 'payload'
 import { fileURLToPath } from 'url'
 
 import { Categories } from './collections/Categories'
@@ -47,6 +47,15 @@ const [NotFoundPage, NotFoundPageCollection] = createSiteGlobal(NotFoundPageConf
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
+// Predeclare the roles and permissions page component to conform views values with AdminViewConfig
+const UserRolesAndPermissionsView: AdminViewConfig = {
+  Component: '@/components/UserRolesAndPermissions',
+  path: '/sites-roles-and-permissions',
+  meta: {
+    title: 'Payload - Sites Roles and Permissions'
+  }
+}
+
 const config = {
   admin: {
     theme: 'light' as const,
@@ -64,6 +73,7 @@ const config = {
         dashboard: {
           Component: '@/components/CustomDashboard',
         },
+        userRolesAndPermissions: UserRolesAndPermissionsView,
       },
     },
     groups: [


### PR DESCRIPTION
Closes #155 

## Changes proposed in this pull request:

- Adds a new page for Sites Roles and Permissions to provide documentation on user management
- Adds a card under User Management in the dashboard
- Includes a new description component for the Users collection page so a link can be added that points to the new page.
- New page utilizes Accordion and In-page navigation elements. Added client-side code to power those as well as previously not forwarded SCSS
- Provides a workaround for problematic Breadcrumbs behavior

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

There are no security concerns 
