### PR TITLE
fix: Home Page card length from 6 to 24

### DIFF
--- a/src/globals/HomePage.ts
+++ b/src/globals/HomePage.ts
@@ -119,7 +119,7 @@ export const HomePage: GlobalConfig = {
               type: 'array',
               label: 'Content Cards',
               minRows: 1,
-              maxRows: 6,
+              maxRows: 24,
               fields: [
                 {
                   name: 'title',


### PR DESCRIPTION
Closes https://github.com/cloud-gov/pages-editor/issues/216

## Changes proposed in this pull request:

- Updates the Home Page's card field to allow up to 24 cards from 6

## Security considerations

None
