### PR TITLE
Create a custom card grid component for rich text editors

### DIFF
--- a/src/blocks/CardGrid.ts
+++ b/src/blocks/CardGrid.ts
@@ -1,0 +1,64 @@
+import { Block } from "payload";
+
+// create column number options
+const columnOptions = Array.from({ length: 6}, (_, i) => {
+  const value = (i + 1).toString();
+  return {label: value, value};
+});
+
+export const CardGridBlock: Block = {
+  slug: 'cardGrid',
+  labels: { singular: 'Card Grid', plural: 'Card Grids'},
+  fields: [
+    {
+      name: 'numberOfColumns',
+      label: 'Number of columns',
+      type: 'select',
+      defaultValue: 1,
+      options: columnOptions,
+      admin: {
+        description:
+          'Select the number of columns in the card grid.'
+      }
+    },
+    {
+      name: 'cards',
+      type: 'array',
+      admin: { initCollapsed: false },
+      fields: [
+        {
+          name: 'image',
+          type: 'upload',
+          label: 'Image',
+          relationTo: 'media',
+          admin: {
+            description: 'Card image',
+          }
+        },
+        {
+          name: 'title',
+          type: 'text',
+        },
+        {
+          name: 'description',
+          type: 'textarea',
+          maxLength: 300,
+        },
+        {
+          name: 'orientation',
+          type: 'select',
+          defaultValue: 'vertical',
+          options: [
+            { label: 'Vertical', value: 'vertical'},
+            { label: 'Horizontal', value: 'horizontal' },
+            { label: 'Horizontal Right', value: 'horizontal-right'}
+          ],
+          admin: {
+            description: 
+              'Select vertical, horizontal, or horizontal with image to the right.'
+          },
+        }
+      ]
+    }
+  ]
+}

--- a/src/utilities/editor.ts
+++ b/src/utilities/editor.ts
@@ -1,5 +1,6 @@
 // standardize our editor features
 import { AccordionBlock } from '@/blocks/Accordion'
+import { CardGridBlock } from '@/blocks/CardGrid'
 import { ProcessListBlock } from '@/blocks/ProcessList'
 import { 
   lexicalEditor,
@@ -14,7 +15,7 @@ export const editor = lexicalEditor({
     FixedToolbarFeature(),
     EXPERIMENTAL_TableFeature(),
     BlocksFeature({
-      blocks: [ProcessListBlock, AccordionBlock],
+      blocks: [ProcessListBlock, AccordionBlock, CardGridBlock],
     }),
   ],
 })


### PR DESCRIPTION
Closes #237 
## Changes proposed in this pull request:

- Adds CardGrid as a BlocksFeature to allow users to create a card grid component
  - user can select number of columns 1 - 6
  - cards have optional image, title, and description fields
  - cards may be set up as vertical or horizontal - "flag" orientation (left or right image placement)
  
 ### pages-site-gantry implementation notes
  
  CardGrid slug: 'cardGrid'
  
 Block node schema
```
 {
   id:
   image: {
     id:
     altText:
     ...
     url:
     filename:
   title:
   description:
   orientation: ( vertical, horizontal, horizontal-right )
 }
```

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This change adds a CardGrid FeatureBlock and doesn't create security exposure
