### PR TITLE
feat: Image size in lexical editor

### DIFF
--- a/src/blocks/Image.ts
+++ b/src/blocks/Image.ts
@@ -1,0 +1,66 @@
+import { Block } from "payload";
+
+export const ImageBlock: Block = {
+  slug: 'image',
+  labels: { singular: 'Image', plural: 'Images' },
+  fields: [
+    {
+      name: 'image',
+      type: 'upload',
+      label: 'Image',
+      relationTo: 'media',
+      required: true,
+      admin: {
+        description: 'Select an image to display',
+      },
+    },
+    {
+      name: 'altText',
+      type: 'text',
+      label: 'Alt Text',
+      admin: {
+        description: 'Image description for accessibility',
+      },
+    },
+    {
+      name: 'width',
+      type: 'select',
+      label: 'Image Width',
+      defaultValue: 'tablet',
+      options: [
+        { label: 'Full Width', value: 'full' },
+        { label: 'Desktop (1024px)', value: 'desktop' },
+        { label: 'Tablet (640px)', value: 'tablet' },
+        { label: 'Mobile (480px)', value: 'mobile' },
+        { label: 'Mobile Small (320px)', value: 'mobile-sm' },
+        { label: 'Custom', value: 'custom' },
+      ],
+      admin: {
+        description: 'Select the maximum width for this image',
+      },
+    },
+    {
+      name: 'customWidth',
+      type: 'text',
+      label: 'Custom Width',
+      admin: {
+        condition: (data, siblingData) => siblingData?.width === 'custom' || data?.width === 'custom',
+        description: 'Enter a custom width (e.g., "600px", "50%", "40rem")',
+      },
+    },
+    {
+      name: 'align',
+      type: 'select',
+      label: 'Alignment',
+      defaultValue: 'left',
+      options: [
+        { label: 'Left', value: 'left' },
+        { label: 'Center', value: 'center' },
+        { label: 'Right', value: 'right' },
+      ],
+      admin: {
+        description: 'Align the image horizontally',
+      },
+    },
+  ],
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -93,7 +93,6 @@ export interface Config {
     'form-submissions': FormSubmission;
     search: Search;
     users: User;
-    'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -130,7 +129,6 @@ export interface Config {
     'form-submissions': FormSubmissionsSelect<false> | FormSubmissionsSelect<true>;
     search: SearchSelect<false> | SearchSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
-    'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -138,7 +136,6 @@ export interface Config {
   db: {
     defaultIDType: number;
   };
-  fallbackLocale: null;
   globals: {
     'site-config': SiteConfig;
     menu: Menu;
@@ -195,7 +192,7 @@ export interface Alert {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -287,7 +284,7 @@ export interface Post {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -426,7 +423,7 @@ export interface Event {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -514,7 +511,7 @@ export interface News {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -596,7 +593,7 @@ export interface Report {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -676,7 +673,7 @@ export interface Resource {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -757,7 +754,7 @@ export interface Leadership {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -852,7 +849,7 @@ export interface CustomCollectionPage {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -921,7 +918,7 @@ export interface Page {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -1048,7 +1045,7 @@ export interface Policy {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -1322,7 +1319,7 @@ export interface HomePageSiteCollection {
               root: {
                 type: string;
                 children: {
-                  type: any;
+                  type: string;
                   version: number;
                   [k: string]: unknown;
                 }[];
@@ -1361,7 +1358,7 @@ export interface FooterSiteCollection {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -1754,7 +1751,7 @@ export interface NotFoundPageSiteCollection {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -1834,7 +1831,7 @@ export interface Form {
               root: {
                 type: string;
                 children: {
-                  type: any;
+                  type: string;
                   version: number;
                   [k: string]: unknown;
                 }[];
@@ -1917,7 +1914,7 @@ export interface Form {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -1949,7 +1946,7 @@ export interface Form {
           root: {
             type: string;
             children: {
-              type: any;
+              type: string;
               version: number;
               [k: string]: unknown;
             }[];
@@ -2012,23 +2009,6 @@ export interface Search {
     | null;
   updatedAt: string;
   createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "payload-kv".
- */
-export interface PayloadKv {
-  id: number;
-  key: string;
-  data:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -3260,14 +3240,6 @@ export interface UsersSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "payload-kv_select".
- */
-export interface PayloadKvSelect<T extends boolean = true> {
-  key?: T;
-  data?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents_select".
  */
 export interface PayloadLockedDocumentsSelect<T extends boolean = true> {
@@ -3553,7 +3525,7 @@ export interface HomePage {
               root: {
                 type: string;
                 children: {
-                  type: any;
+                  type: string;
                   version: number;
                   [k: string]: unknown;
                 }[];
@@ -3591,7 +3563,7 @@ export interface Footer {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];
@@ -3982,7 +3954,7 @@ export interface NotFoundPage {
     root: {
       type: string;
       children: {
-        type: any;
+        type: string;
         version: number;
         [k: string]: unknown;
       }[];

--- a/src/utilities/editor.ts
+++ b/src/utilities/editor.ts
@@ -2,6 +2,7 @@
 import { AccordionBlock } from '@/blocks/Accordion'
 import { CardGridBlock } from '@/blocks/CardGrid'
 import { ProcessListBlock } from '@/blocks/ProcessList'
+import { ImageBlock } from '@/blocks/Image'
 import { 
   lexicalEditor,
   FixedToolbarFeature,
@@ -15,7 +16,7 @@ export const editor = lexicalEditor({
     FixedToolbarFeature(),
     EXPERIMENTAL_TableFeature(),
     BlocksFeature({
-      blocks: [ProcessListBlock, AccordionBlock, CardGridBlock],
+      blocks: [ProcessListBlock, AccordionBlock, CardGridBlock, ImageBlock],
     }),
   ],
 })


### PR DESCRIPTION
## Changes proposed in this pull request:

- Added a new Image block type to the lexical editor with slug 'image' for inserting images into rich text.
- Implemented width options: Full Width, Desktop (1024px), Tablet (640px, default), Mobile (480px), Mobile Small (320px), and Custom (with user-defined width).
- Added alignment options (Left, Center, Right) that apply when width is not full.
- Included accessibility: required image upload field and optional alt text (falls back to null alt text if not provided).
- Registered the ImageBlock in the editor configuration alongside ProcessList, Accordion, and CardGrid blocks, making it available in all rich text fields.

## Security considerations

None