### PR TITLE
fix: css in collection list view header buttons

### DIFF
--- a/src/app/(payload)/custom.scss
+++ b/src/app/(payload)/custom.scss
@@ -113,7 +113,7 @@ label.field-label:not(.unstyled) {
     --bg-color: var(--color-primary-darker);
 }
 
-.list-header .btn {
+.list-header .btn:not(.btn--style-none) {
     background-color: var(--color-primary-darker);
 }
 


### PR DESCRIPTION
Closes: #256 
## Changes proposed in this pull request:

- Narrows the scope of the styling on header buttons to exclude .btn--style-none classed buttons

<img width="1339" height="576" alt="Screenshot 2026-02-17 at 9 30 47 AM (2)" src="https://github.com/user-attachments/assets/f4d5f7f1-9aee-4c8f-8e69-b1e66deda640" />

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No.  This is a CSS edit.
