### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 0.4.0 (2026-04-14)
+
+### Added
+
+- Add layout type to collection types for list or card grid view
+- Refine ATU package and dashboard
+- add active state to admin nav links
+- **ci**: Add access tests to SiteAuth collection and ATU package
+- Add site ATU package for managers to download
+- Add site auth global collection to manage ATU
+- Add site compliance ATU Package and compliance section
+- Add site compliance ATU docs page
+- Add side nav collection to collection entries and pages
+- Add collection type edit link in type card
+- Add build site hook on record unpublish or delete
+
+### Fixed
+
+- call headers with await
+- typescript errors
+- Table heading width to allow the first heading to expand based on content
+- Collection entry preview and dev site gantry version build
+
+### Maintenance
+
+- replace merged Nav components
+- Remove security considerations action
+
 ## 0.3.0 (2026-03-11)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pages-editor",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pages-editor",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.787.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pages-editor",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A customized Payload CMS editor for creating and managing federal websites",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.4.0
tag to create: 0.4.0
increment detected: MINOR

## 0.4.0 (2026-04-14)

### Added

- Add layout type to collection types for list or card grid view
- Refine ATU package and dashboard
- add active state to admin nav links
- **ci**: Add access tests to SiteAuth collection and ATU package
- Add site ATU package for managers to download
- Add site auth global collection to manage ATU
- Add site compliance ATU Package and compliance section
- Add site compliance ATU docs page
- Add side nav collection to collection entries and pages
- Add collection type edit link in type card
- Add build site hook on record unpublish or delete

### Fixed

- call headers with await
- typescript errors
- Table heading width to allow the first heading to expand based on content
- Collection entry preview and dev site gantry version build

### Maintenance

- replace merged Nav components
- Remove security considerations action
## security considerations
Noted in individual PRs
