### PR TITLE
fix: call headers with await

### DIFF
--- a/src/components/CustomDashboard/Nav.tsx
+++ b/src/components/CustomDashboard/Nav.tsx
@@ -5,7 +5,7 @@ import { buildFilteredUrl, getCollectionTypes, getUserSiteInfo } from '@/compone
 import NavClient from './NavClient'
 
 const Nav: React.FC<{ payload: BasePayload }> = async ({ payload }) => {
-  const headers = nextHeaders()
+  const headers = await nextHeaders()
 
   const collectionTypes = await getCollectionTypes(payload, headers)
   const collectionTypeLinks = collectionTypes.docs.map(ct => ({


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixes a console error when clicking a Nav link
- Error: Route "/admin/[[...segments]]" used `headers().get('Cookie')`. `headers()` should be awaited before using its value.
- https://nextjs.org/docs/messages/sync-dynamic-apis

Applies "await" to setting the `headers` variable.

<img width="1279" height="300" alt="Screenshot 2026-04-03 at 1 27 10 PM (2)" src="https://github.com/user-attachments/assets/031ffeb2-65e7-4f28-9419-462ffb05f772" />


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No
