### PR TITLE
fix: Leaving EMAIL_HOST on .env.example empty

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,4 @@ AWS_SECRET_ACCESS_KEY=pages-editor-secret-key
 AWS_REGION=us-gov-west-1
 BUCKET_MANAGER_AWS_ACCESS_KEY_ID=pages-editor-access-key
 BUCKET_MANAGER_AWS_SECRET_ACCESS_KEY=pages-editor-secret-key
-EMAIL_HOST=email.example.gov
+EMAIL_HOST=


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove the value from EMAIL_HOST in .env.example

## Reason for removing the value from EMAIL_HOST

When running seed data locally, the creation of new users triggers an email sending hook. Since local development environments typically lack an SMTP server for test accounts, attempting to send these emails will cause failures.

To prevent these errors and ensure smooth local seeding, we changed the `EMAIL_HOST` to be empty in .env.example. 
This will disable email sending during the seeding process.


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Does not leverage any secret keys or expose data.
