### PR TITLE
fix: IFrame CSP headers to allow cloud.gov preview urls

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+const cgSources = '*.app.cloud.gov *.cloud.gov'
+
 export function middleware(request: NextRequest) {
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
   const isDev = process.env.NODE_ENV === 'development'
@@ -12,7 +14,8 @@ export function middleware(request: NextRequest) {
     object-src 'none';
     base-uri 'self';
     form-action 'self';
-    frame-ancestors 'none';
+    frame-ancestors 'self' ${cgSources};
+    frame-src: ${cgSources};
     upgrade-insecure-requests;
 `
   // Replace newline characters and spaces


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixes previewing error by allowing `iframe` to pull from site preview urls
