### PR TITLE
chore: Adjusting CSP configs for built in component styles

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const cgSources = '*.app.cloud.gov *.cloud.gov'
-
 export function middleware(request: NextRequest) {
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
   const isDev = process.env.NODE_ENV === 'development'

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,12 +12,12 @@ export function middleware(request: NextRequest) {
     style-src 'self' 'unsafe-inline';
     img-src 'self' blob: data:;
     font-src 'self';
-    object-src 'self';
+    object-src 'none';
     base-uri 'self';
     form-action 'self';
-    frame-ancestors: 'none';
-    frame-src: 'self' ${cgSources};
-    child-src: 'self' ${cgSources};
+    connect-src 'self';
+    frame-ancestors 'none';
+    frame-src 'self' ${cgSources};
     upgrade-insecure-requests;
 `
   // Replace newline characters and spaces

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,12 +9,13 @@ export function middleware(request: NextRequest) {
   const cspHeader = `
     default-src 'self' ${cgSources};
     script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ''};
-    style-src 'self' 'nonce-${nonce}';
+    style-src 'self' 'unsafe-inline';
     img-src 'self' blob: data:;
     font-src 'self';
     object-src 'self';
     base-uri 'self';
     form-action 'self';
+    frame-ancestors: 'none';
     frame-src: 'self' ${cgSources};
     child-src: 'self' ${cgSources};
     upgrade-insecure-requests;


### PR DESCRIPTION
Adjusting styles CSP header to allow certain built in UI components to work in Payload admin.

## Changes proposed in this pull request:

- Allows inline styles to re-enable some UI inputs
- Sets frame ancestors to none
- Removes unused variable
