### PR TITLE
chore: remove inline css

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,9 @@
     "js-cookie": "3.0.7",
     "postcss": "^8.5.15",
     "esbuild": "0.28.0",
-    "@eslint/plugin-kit": "^0.3.4"
+    "@eslint/plugin-kit": "^0.3.4",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@img/sharp-libvips-linux-x64": "1.2.4"
   },
   "optionalDependencies": {
     "@esbuild/darwin-arm64": "^0.25.2",

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -28,6 +28,8 @@ import { FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e0
 import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
 import { default as default_ad353b06f24a8b84aa5b713b301b2c62 } from 'src/components/UpdatedByCellData/'
 import { RelationshipField as RelationshipField_25000ababc07f3d3a330f7afaf35f496 } from '@/components/fields/RelationshipField'
+import { FileUploadField as FileUploadField_89975e5460f876d1cd61ed8c059aae35 } from '@/components/FileUploadField'
+import { FilesField as FilesField_38e938fec57b6cbc3acc8934574dc824 } from '@/components/FilesField'
 import { UswdsColorSelect as UswdsColorSelect_c5ee67a32f6c03c5e346f5f1b5ad0635 } from '@/fields/styles/UswdsColorSelect'
 import { default as default_9c394c8955c2623071876ecbca9cadca } from '@/components/PreFooter/ContactCenterRowLabel'
 import { default as default_8bfd6f3f91a8dc4d92146132e8cad3de } from '@/components/PreFooter/FacebookLinkRowLabel'
@@ -86,6 +88,8 @@ export const importMap = {
   "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
   "src/components/UpdatedByCellData/#default": default_ad353b06f24a8b84aa5b713b301b2c62,
   "@/components/fields/RelationshipField#RelationshipField": RelationshipField_25000ababc07f3d3a330f7afaf35f496,
+  "@/components/FileUploadField#FileUploadField": FileUploadField_89975e5460f876d1cd61ed8c059aae35,
+  "@/components/FilesField#FilesField": FilesField_38e938fec57b6cbc3acc8934574dc824,
   "@/fields/styles/UswdsColorSelect#UswdsColorSelect": UswdsColorSelect_c5ee67a32f6c03c5e346f5f1b5ad0635,
   "@/components/PreFooter/ContactCenterRowLabel#default": default_9c394c8955c2623071876ecbca9cadca,
   "@/components/PreFooter/FacebookLinkRowLabel#default": default_8bfd6f3f91a8dc4d92146132e8cad3de,

--- a/src/components/DragDropCustom/index.scss
+++ b/src/components/DragDropCustom/index.scss
@@ -1,0 +1,15 @@
+.files-draggable {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--base) / 2);
+
+  &__item {
+    position: relative;
+
+    &--is-dragging {
+      z-index: 2;
+      cursor: grabbing;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    }
+  }
+}

--- a/src/components/DragDropCustom/index.test.tsx
+++ b/src/components/DragDropCustom/index.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+
+import { DragDropCustomList, DragDropCustomItem } from './index'
+
+const renderList = (ids: string[], onDragEnd = vi.fn()) =>
+  render(
+    <DragDropCustomList ids={ids} onDragEnd={onDragEnd}>
+      {ids.map((id) => (
+        <DragDropCustomItem id={id} key={id}>
+          {({ attributes, isDragging, listeners }) => (
+            <div
+              data-dragging={isDragging}
+              data-testid={`item-${id}`}
+              {...attributes}
+              {...listeners}
+            >
+              {id}
+            </div>
+          )}
+        </DragDropCustomItem>
+      ))}
+    </DragDropCustomList>,
+  )
+
+describe('DragDropCustom', () => {
+  it('renders the list wrapper and all items', () => {
+    const { container } = renderList(['a', 'b', 'c'])
+
+    expect(container.querySelector('.files-draggable')).toBeInTheDocument()
+    expect(screen.getByTestId('item-a')).toHaveTextContent('a')
+    expect(screen.getByTestId('item-b')).toHaveTextContent('b')
+    expect(screen.getByTestId('item-c')).toHaveTextContent('c')
+  })
+
+  it('wraps each child in a draggable item element', () => {
+    const { container } = renderList(['a', 'b'])
+
+    const items = container.querySelectorAll('.files-draggable__item')
+    expect(items).toHaveLength(2)
+  })
+
+  it('exposes a render-prop API with attributes, isDragging and listeners', () => {
+    const child = vi.fn((_props: unknown) => <div data-testid="rp">x</div>)
+
+    render(
+      <DragDropCustomList ids={['only']} onDragEnd={vi.fn()}>
+        <DragDropCustomItem id="only">{child}</DragDropCustomItem>
+      </DragDropCustomList>,
+    )
+
+    expect(child).toHaveBeenCalled()
+    const args = child.mock.calls[0]![0] as {
+      attributes: Record<string, unknown>
+      isDragging: boolean
+      listeners: { onPointerDown?: unknown }
+    }
+    expect(args).toHaveProperty('attributes')
+    expect(args.isDragging).toBe(false)
+    expect(typeof args.listeners.onPointerDown).toBe('function')
+  })
+
+  it('starts each item in a non-dragging state', () => {
+    renderList(['a', 'b'])
+    expect(screen.getByTestId('item-a')).toHaveAttribute('data-dragging', 'false')
+    expect(screen.getByTestId('item-b')).toHaveAttribute('data-dragging', 'false')
+  })
+
+  it('renders a list wrapper for an empty set of ids', () => {
+    const { container } = render(
+      <DragDropCustomList ids={[]} onDragEnd={vi.fn()}>
+        {null}
+      </DragDropCustomList>,
+    )
+    const list = container.querySelector('.files-draggable')
+    expect(list).toBeInTheDocument()
+    expect(within(list as HTMLElement).queryByTestId(/item-/)).toBeNull()
+  })
+})

--- a/src/components/DragDropCustom/index.tsx
+++ b/src/components/DragDropCustom/index.tsx
@@ -1,0 +1,454 @@
+'use client'
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
+
+import './index.scss'
+
+const baseClass = 'files-draggable'
+
+type DragEndArgs = { moveFromIndex: number; moveToIndex: number }
+
+type DragDropContextValue = {
+  activeId: string | null
+  ids: string[]
+  registerItem: (id: string, node: HTMLElement | null) => void
+  startDrag: (id: string, event: ReactPointerEvent) => void
+}
+
+const DragDropContext = createContext<DragDropContextValue | null>(null)
+
+const useDragDropContext = () => {
+  const context = useContext(DragDropContext)
+  if (!context) {
+    throw new Error('DragDropCustomItem must be used within a DragDropCustomList')
+  }
+  return context
+}
+
+const EASING = 'cubic-bezier(0, 0.2, 0.2, 1)'
+const DURATION = 200
+
+export type DragDropCustomItemRenderProps = {
+  attributes: { 'aria-grabbed'?: boolean }
+  isDragging: boolean
+  listeners: {
+    onPointerDown: (event: ReactPointerEvent) => void
+  }
+}
+
+type DragDropCustomListProps = {
+  children: React.ReactNode
+  className?: string
+  ids: string[]
+  onDragEnd: (args: DragEndArgs) => void
+}
+
+export const DragDropCustomList: React.FC<DragDropCustomListProps> = ({
+  children,
+  className,
+  ids,
+  onDragEnd,
+}) => {
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const idsRef = useRef(ids)
+  idsRef.current = ids
+
+  const itemNodes = useRef(new Map<string, HTMLElement>())
+  const previousRects = useRef(new Map<string, DOMRect>())
+  const currentShift = useRef(new Map<string, number>())
+  const shouldAnimate = useRef(false)
+  const orderKey = ids.join('|')
+
+  const dragState = useRef<{
+    draggedId: string
+    height: number
+    maxDelta: number
+    minDelta: number
+    pointerClientY: number
+    restingCenters: { id: string; center: number }[]
+    scrollContainer: HTMLElement | Window
+    startPageY: number
+    targetIndex: number
+  } | null>(null)
+
+  const rafId = useRef<number | null>(null)
+
+  React.useEffect(
+    () => () => {
+      if (rafId.current !== null) {
+        cancelAnimationFrame(rafId.current)
+      }
+    },
+    [],
+  )
+
+  const registerItem = useCallback((id: string, node: HTMLElement | null) => {
+    if (node) {
+      itemNodes.current.set(id, node)
+    } else {
+      itemNodes.current.delete(id)
+    }
+  }, [])
+
+  const captureRects = useCallback(() => {
+    const rects = new Map<string, DOMRect>()
+    itemNodes.current.forEach((node, id) => {
+      rects.set(id, node.getBoundingClientRect())
+    })
+    return rects
+  }, [])
+
+  const getGap = useCallback(() => {
+    const first = itemNodes.current.values().next().value as HTMLElement | undefined
+    const parent = first?.parentElement
+    if (!parent) {
+      return 0
+    }
+    const gap = parseFloat(getComputedStyle(parent).rowGap || '0')
+    return Number.isNaN(gap) ? 0 : gap
+  }, [])
+
+  const animateShiftTo = useCallback((id: string, target: number) => {
+    const node = itemNodes.current.get(id)
+    if (!node) {
+      return
+    }
+    const from = currentShift.current.get(id) ?? 0
+    if (from === target) {
+      return
+    }
+    currentShift.current.set(id, target)
+    const animation = node.animate(
+      [{ transform: `translateY(${from}px)` }, { transform: `translateY(${target}px)` }],
+      { duration: DURATION, easing: EASING, fill: 'forwards' },
+    )
+    if (target === 0) {
+      animation.onfinish = () => {
+        animation.cancel()
+        currentShift.current.delete(id)
+      }
+    }
+  }, [])
+
+  const applyShifts = useCallback(
+    (draggedId: string, targetIndex: number, rowHeight: number) => {
+      const ids = idsRef.current
+      const draggedIndex = ids.findIndex((id) => id === draggedId)
+      if (draggedIndex === -1) {
+        return
+      }
+      ids.forEach((id, index) => {
+        if (id === draggedId) {
+          return
+        }
+        let shift = 0
+        if (draggedIndex < targetIndex && index > draggedIndex && index <= targetIndex) {
+          shift = -rowHeight
+        } else if (draggedIndex > targetIndex && index >= targetIndex && index < draggedIndex) {
+          shift = rowHeight
+        }
+        animateShiftTo(id, shift)
+      })
+    },
+    [animateShiftTo],
+  )
+
+  const clearShifts = useCallback(() => {
+    Array.from(currentShift.current.keys()).forEach((id) => animateShiftTo(id, 0))
+  }, [animateShiftTo])
+
+  // FLIP settle after a committed reorder.
+  useLayoutEffect(() => {
+    if (!shouldAnimate.current) {
+      return
+    }
+    shouldAnimate.current = false
+    const previous = previousRects.current
+    itemNodes.current.forEach((node, id) => {
+      const oldRect = previous.get(id)
+      if (!oldRect) {
+        return
+      }
+      const newRect = node.getBoundingClientRect()
+      const deltaY = oldRect.top - newRect.top
+      if (deltaY) {
+        node.animate(
+          [{ transform: `translateY(${deltaY}px)` }, { transform: 'translateY(0)' }],
+          { duration: DURATION, easing: EASING },
+        )
+      }
+    })
+  }, [orderKey])
+
+  const startDrag = useCallback(
+    (id: string, event: ReactPointerEvent) => {
+      const node = itemNodes.current.get(id)
+      if (!node) {
+        return
+      }
+      const rect = node.getBoundingClientRect()
+      const draggedIndex = idsRef.current.findIndex((rowId) => rowId === id)
+      const pageY = event.clientY + window.scrollY
+      const restingCenters = idsRef.current.map((rowId) => {
+        const rowNode = itemNodes.current.get(rowId)
+        const r = rowNode?.getBoundingClientRect()
+        return { id: rowId, center: r ? r.top + window.scrollY + r.height / 2 : 0 }
+      })
+
+      const findScrollContainer = (el: HTMLElement | null): HTMLElement | Window => {
+        let current = el?.parentElement ?? null
+        while (current) {
+          const style = getComputedStyle(current)
+          const overflowY = style.overflowY
+          if (
+            (overflowY === 'auto' || overflowY === 'scroll') &&
+            current.scrollHeight > current.clientHeight
+          ) {
+            return current
+          }
+          current = current.parentElement
+        }
+        return window
+      }
+
+      dragState.current = {
+        draggedId: id,
+        height: rect.height + getGap(),
+        ...(() => {
+          const listEl = node.parentElement
+          if (listEl) {
+            const listRect = listEl.getBoundingClientRect()
+            const listTop = listRect.top + window.scrollY
+            const listBottom = listRect.bottom + window.scrollY
+            const rowTop = rect.top + window.scrollY
+            const rowBottom = rect.bottom + window.scrollY
+            return {
+              maxDelta: listBottom - rowBottom,
+              minDelta: listTop - rowTop,
+            }
+          }
+          return { maxDelta: Infinity, minDelta: -Infinity }
+        })(),
+        pointerClientY: event.clientY,
+        restingCenters,
+        scrollContainer: findScrollContainer(node),
+        startPageY: pageY,
+        targetIndex: draggedIndex,
+      }
+      setActiveId(id)
+
+      const update = () => {
+        const state = dragState.current
+        if (!state) {
+          return
+        }
+        const pointerPageY = state.pointerClientY + window.scrollY
+
+        const draggedNode = itemNodes.current.get(state.draggedId)
+        if (draggedNode) {
+          const rawDelta = pointerPageY - state.startPageY
+          const deltaY = Math.max(state.minDelta, Math.min(state.maxDelta, rawDelta))
+          draggedNode.animate([{ transform: `translateY(${deltaY}px)` }], {
+            duration: 0,
+            fill: 'forwards',
+          })
+        }
+
+        const rawDelta = pointerPageY - state.startPageY
+        const clampedDelta = Math.max(state.minDelta, Math.min(state.maxDelta, rawDelta))
+
+        const draggedTop = state.startPageY + clampedDelta
+        const draggedBottom = draggedTop + state.height
+
+        let computed = 0
+        state.restingCenters.forEach(({ id: rowId, center }) => {
+          if (rowId === state.draggedId) {
+            return
+          }
+          if (center < state.startPageY) {
+            if (draggedTop >= center) {
+              computed += 1
+            }
+          } else {
+            if (draggedBottom > center) {
+              computed += 1
+            }
+          }
+        })
+        const ids = idsRef.current
+        computed = Math.max(0, Math.min(computed, ids.length - 1))
+        if (computed !== state.targetIndex) {
+          state.targetIndex = computed
+          applyShifts(state.draggedId, computed, state.height)
+        }
+      }
+
+      const EDGE = 60
+      const MAX_SPEED = 18
+      const autoScrollStep = () => {
+        const state = dragState.current
+        if (!state) {
+          rafId.current = null
+          return
+        }
+        const container = state.scrollContainer
+        let top: number
+        let bottom: number
+        if (container === window) {
+          top = 0
+          bottom = window.innerHeight
+        } else {
+          const r = (container as HTMLElement).getBoundingClientRect()
+          top = r.top
+          bottom = r.bottom
+        }
+        const y = state.pointerClientY
+        let delta = 0
+        if (y < top + EDGE) {
+          delta = -MAX_SPEED * ((top + EDGE - y) / EDGE)
+        } else if (y > bottom - EDGE) {
+          delta = MAX_SPEED * ((y - (bottom - EDGE)) / EDGE)
+        }
+        if (delta !== 0) {
+          if (container === window) {
+            window.scrollBy(0, delta)
+          } else {
+            ;(container as HTMLElement).scrollTop += delta
+          }
+          update()
+        }
+        rafId.current = requestAnimationFrame(autoScrollStep)
+      }
+
+      const handleScroll = () => {
+        update()
+      }
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        const state = dragState.current
+        if (!state) {
+          return
+        }
+        state.pointerClientY = moveEvent.clientY
+        update()
+      }
+
+      const handleUp = () => {
+        window.removeEventListener('pointermove', handleMove)
+        window.removeEventListener('pointerup', handleUp)
+        window.removeEventListener('scroll', handleScroll, true)
+        if (rafId.current !== null) {
+          cancelAnimationFrame(rafId.current)
+          rafId.current = null
+        }
+
+        const state = dragState.current
+        dragState.current = null
+
+        const draggedNode = state ? itemNodes.current.get(state.draggedId) : undefined
+        draggedNode?.getAnimations().forEach((animation) => animation.cancel())
+
+        if (state) {
+          const ids = idsRef.current
+          const moveFromIndex = ids.findIndex((rowId) => rowId === state.draggedId)
+          const moveToIndex = state.targetIndex
+          if (moveFromIndex !== -1 && moveToIndex !== moveFromIndex) {
+            itemNodes.current.forEach((rowNode) => {
+              rowNode.getAnimations().forEach((animation) => animation.cancel())
+            })
+            currentShift.current.clear()
+            previousRects.current = captureRects()
+            shouldAnimate.current = true
+            onDragEnd({ moveFromIndex, moveToIndex })
+          } else {
+            clearShifts()
+          }
+        }
+        setActiveId(null)
+      }
+
+      window.addEventListener('pointermove', handleMove)
+      window.addEventListener('pointerup', handleUp)
+      window.addEventListener('scroll', handleScroll, true)
+      rafId.current = requestAnimationFrame(autoScrollStep)
+    },
+    [applyShifts, captureRects, clearShifts, getGap, onDragEnd],
+  )
+
+  const contextValue = useMemo<DragDropContextValue>(
+    () => ({
+      activeId,
+      ids,
+      registerItem,
+      startDrag,
+    }),
+    [activeId, ids, registerItem, startDrag],
+  )
+
+  return (
+    <DragDropContext.Provider value={contextValue}>
+      <div className={[baseClass, className].filter(Boolean).join(' ')}>{children}</div>
+    </DragDropContext.Provider>
+  )
+}
+
+type DragDropCustomItemProps = {
+  children: (props: DragDropCustomItemRenderProps) => React.ReactNode
+  className?: string
+  disabled?: boolean
+  id: string
+}
+
+export const DragDropCustomItem: React.FC<DragDropCustomItemProps> = ({
+  children,
+  disabled,
+  id,
+}) => {
+  const { activeId, registerItem, startDrag } = useDragDropContext()
+
+  const setItemRef = useCallback(
+    (node: HTMLElement | null) => {
+      registerItem(id, node)
+    },
+    [id, registerItem],
+  )
+
+  const isDragging = activeId === id
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent) => {
+      if (disabled || event.button !== 0) {
+        return
+      }
+      event.preventDefault()
+      startDrag(id, event)
+    },
+    [disabled, id, startDrag],
+  )
+
+  return (
+    <div
+      className={[`${baseClass}__item`, isDragging ? `${baseClass}__item--is-dragging` : '']
+        .filter(Boolean)
+        .join(' ')}
+      ref={setItemRef}
+    >
+      {children({
+        attributes: { 'aria-grabbed': isDragging || undefined },
+        isDragging,
+        listeners: {
+          onPointerDown: handlePointerDown,
+        },
+      })}
+    </div>
+  )
+}

--- a/src/components/FileUploadField/index.test.tsx
+++ b/src/components/FileUploadField/index.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import { FileUploadField } from './index'
+
+const mockSetValue = vi.fn()
+const mockUseField = vi.fn()
+
+vi.mock('@payloadcms/ui', () => ({
+  useConfig: () => ({
+    config: { routes: { api: '/api' }, serverURL: 'http://localhost' },
+  }),
+  useField: (args: unknown) => mockUseField(args),
+  // Render a representative thumbnail so the sanitizer has something to act on.
+  UploadInput: ({ value }: { value?: unknown }) => (
+    <div className="upload-field-card">
+      <div className="thumbnail">
+        <svg viewBox="0 0 150 150" style={{ backgroundColor: '#333' }} data-testid="placeholder">
+          <path d="M0 0" />
+        </svg>
+      </div>
+      <span data-testid="upload-value">{JSON.stringify(value ?? null)}</span>
+    </div>
+  ),
+}))
+
+const baseProps = {
+  field: {
+    name: 'file',
+    label: 'File',
+    relationTo: 'media',
+    required: true,
+    admin: {},
+  },
+  path: 'file',
+  readOnly: false,
+} as unknown as React.ComponentProps<typeof FileUploadField>
+
+const baseField = baseProps.field as Record<string, unknown>
+
+const setField = (overrides: Record<string, unknown> = {}) => {
+  mockUseField.mockReturnValue({
+    customComponents: {},
+    disabled: false,
+    filterOptions: undefined,
+    path: 'file',
+    setValue: mockSetValue,
+    showError: false,
+    value: 'media-id',
+    ...overrides,
+  })
+}
+
+describe('FileUploadField', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setField()
+  })
+
+  it('renders Payload UploadInput', () => {
+    render(<FileUploadField {...baseProps} />)
+    expect(screen.getByTestId('upload-value')).toBeInTheDocument()
+  })
+
+  it('strips the inline style from the placeholder svg and tags it', async () => {
+    render(<FileUploadField {...baseProps} />)
+
+    const svg = screen.getByTestId('placeholder')
+    await waitFor(() => {
+      expect(svg.hasAttribute('style')).toBe(false)
+    })
+    expect(svg).toHaveAttribute('data-file-placeholder', 'true')
+  })
+
+  it('passes the raw value through for single (non-hasMany) uploads', () => {
+    setField({ value: 'media-id' })
+    render(<FileUploadField {...baseProps} />)
+    expect(screen.getByTestId('upload-value')).toHaveTextContent('"media-id"')
+  })
+
+  it('maps hasMany values into relationTo/value objects', () => {
+    setField({ value: ['a', 'b'] })
+    render(
+      <FileUploadField
+        {...baseProps}
+        field={{ ...baseField, hasMany: true } as never}
+      />,
+    )
+    const text = screen.getByTestId('upload-value').textContent ?? ''
+    expect(text).toContain('"relationTo":"media"')
+    expect(text).toContain('"value":"a"')
+    expect(text).toContain('"value":"b"')
+  })
+
+  it('does not contain inline styles after sanitization', async () => {
+    const { container } = render(<FileUploadField {...baseProps} />)
+    await waitFor(() => {
+      expect(container.querySelector('[style]')).toBeNull()
+    })
+  })
+})

--- a/src/components/FileUploadField/index.tsx
+++ b/src/components/FileUploadField/index.tsx
@@ -1,0 +1,121 @@
+'use client'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import type { UploadFieldClientComponent } from 'payload'
+import { useConfig, useField, UploadInput } from '@payloadcms/ui'
+
+export const FileUploadField: UploadFieldClientComponent = (props) => {
+  const {
+    field,
+    field: {
+      admin: { allowCreate, className, description, isSortable } = {},
+      hasMany,
+      label,
+      localized,
+      maxRows,
+      relationTo: relationToFromProps,
+      required,
+    },
+    path: pathFromProps,
+    readOnly,
+    validate,
+  } = props
+
+  const { config } = useConfig()
+  const displayPreview = (field as { displayPreview?: boolean }).displayPreview
+
+  const memoizedValidate = useCallback(
+    (value: unknown, options: Record<string, unknown>) => {
+      if (typeof validate === 'function') {
+        return validate(value as never, { ...options, required } as never)
+      }
+    },
+    [validate, required],
+  )
+
+  const {
+    customComponents: { AfterInput, BeforeInput, Description, Error, Label } = {},
+    disabled,
+    filterOptions,
+    path,
+    setValue,
+    showError,
+    value,
+  } = useField({
+    potentiallyStalePath: pathFromProps,
+    validate: memoizedValidate as never,
+  })
+
+  const isPolymorphic = Array.isArray(relationToFromProps)
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const root = wrapperRef.current
+    if (!root) {
+      return
+    }
+
+    const sanitize = () => {
+      const svgs = root.querySelectorAll<SVGElement>(
+        '.thumbnail > svg[viewBox="0 0 150 150"][style]',
+      )
+      svgs.forEach((svg) => {
+        svg.removeAttribute('style')
+        svg.setAttribute('data-file-placeholder', 'true')
+      })
+    }
+
+    sanitize()
+    const observer = new MutationObserver(sanitize)
+    observer.observe(root, { attributeFilter: ['style'], childList: true, subtree: true })
+    return () => observer.disconnect()
+  })
+
+  const memoizedValue = useMemo(() => {
+    if (hasMany === true) {
+      return Array.isArray(value)
+        ? value.map((val) =>
+            isPolymorphic
+              ? val
+              : {
+                  relationTo: Array.isArray(relationToFromProps)
+                    ? relationToFromProps[0]
+                    : relationToFromProps,
+                  value: val,
+                },
+          )
+        : value
+    }
+    return value
+  }, [hasMany, value, isPolymorphic, relationToFromProps])
+
+  return (
+    <div ref={wrapperRef}>
+      <UploadInput
+        AfterInput={AfterInput}
+        allowCreate={allowCreate !== false}
+        api={config.routes.api}
+        BeforeInput={BeforeInput}
+        className={className}
+        Description={Description}
+        description={description}
+        displayPreview={displayPreview}
+        Error={Error}
+        filterOptions={filterOptions}
+        hasMany={hasMany}
+        isSortable={isSortable}
+        label={label}
+        Label={Label}
+        localized={localized}
+        maxRows={maxRows}
+        onChange={setValue}
+        path={path}
+        readOnly={readOnly || disabled}
+        relationTo={relationToFromProps}
+        required={required}
+        serverURL={config.serverURL}
+        showError={showError}
+        value={memoizedValue as never}
+      />
+    </div>
+  )
+}

--- a/src/components/FilesField/index.scss
+++ b/src/components/FilesField/index.scss
@@ -1,0 +1,110 @@
+.files-field {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--base) / 2);
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--base) / 2);
+  }
+
+  &--has-no-error {
+    > .files-field__header .files-field__header-content {
+      color: var(--theme-text);
+    }
+  }
+
+  &__header-content {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--base) / 2);
+  }
+
+  &__header-wrap {
+    display: flex;
+    align-items: flex-end;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  &__header-actions {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    color: var(--color-primary-darker, #1a4480);
+  }
+
+  &__header-action {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: var(--color-primary-darker, #1a4480);
+    cursor: pointer;
+    font: inherit;
+    margin-left: calc(var(--base) / 2);
+    padding: 0;
+
+    &:hover,
+    &:focus-visible {
+      text-decoration: underline;
+      color: var(--color-primary-darker, #1a4480);
+    }
+  }
+
+  &__rows {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--base) / 2);
+  }
+
+  &__title {
+    margin-bottom: 0;
+    color: var(--color-primary-darker, #1a4480);
+  }
+
+  &__add-row.btn {
+    align-self: flex-start;
+    margin: 2px 0;
+    --btn-color: var(--theme-elevation-400);
+
+    &:hover:not(:disabled) {
+      --btn-color: var(--theme-elevation-800);
+    }
+
+    &:disabled {
+      --btn-color: var(--theme-elevation-300);
+    }
+
+    .btn__label {
+      color: var(--btn-color);
+    }
+
+    .btn__icon {
+      border-color: var(--btn-color);
+
+      path {
+        stroke: var(--btn-color);
+      }
+    }
+  }
+
+  &--has-error {
+    > .files-field__header .files-field__header-content {
+      color: var(--theme-error-500);
+    }
+  }
+}
+
+html[data-theme='light'] {
+  .files-field--has-error {
+    > .files-field__header .files-field__header-content {
+      color: var(--theme-error-750);
+    }
+  }
+}
+
+svg[data-file-placeholder='true'] {
+  background-color: var(--color-gray-90, #1b1b1b);
+}

--- a/src/components/FilesField/index.test.tsx
+++ b/src/components/FilesField/index.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { FilesField } from './index'
+
+const mockUseField = vi.fn()
+const mockDispatchFields = vi.fn()
+const mockMoveFieldRow = vi.fn()
+const mockSetDocFieldPreferences = vi.fn()
+const mockGetFields = vi.fn(() => ({}))
+const mockReplaceState = vi.fn()
+const mockSetModified = vi.fn()
+
+vi.mock('@payloadcms/ui', () => ({
+  Banner: ({ children }: { children: React.ReactNode }) => <div data-testid="banner">{children}</div>,
+  Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button data-testid="add-row" onClick={onClick} type="button">
+      {children}
+    </button>
+  ),
+  ErrorPill: ({ count }: { count: number }) => <span data-testid="error-pill">{count}</span>,
+  FieldDescription: ({ description }: { description?: string }) => <p>{description}</p>,
+  FieldError: () => <div data-testid="field-error" />,
+  FieldLabel: ({ label }: { label?: string }) => <span data-testid="field-label">{label}</span>,
+  NullifyLocaleField: () => null,
+  RenderCustomComponent: ({ Fallback }: { Fallback: React.ReactNode }) => <>{Fallback}</>,
+  useConfig: () => ({ config: { localization: false } }),
+  useDocumentInfo: () => ({ setDocFieldPreferences: mockSetDocFieldPreferences }),
+  useField: (args: unknown) => mockUseField(args),
+  useForm: () => ({
+    addFieldRow: vi.fn(),
+    dispatchFields: mockDispatchFields,
+    getFields: mockGetFields,
+    moveFieldRow: mockMoveFieldRow,
+    removeFieldRow: vi.fn(),
+    replaceState: mockReplaceState,
+    setModified: mockSetModified,
+  }),
+  useFormSubmitted: () => true,
+  useLocale: () => ({ code: 'en' }),
+  useTranslation: () => ({ i18n: {}, t: (key: string) => key }),
+}))
+
+vi.mock('@payloadcms/ui/utilities/scrollToID', () => ({ scrollToID: vi.fn() }))
+vi.mock('@payloadcms/translations', () => ({
+  getTranslation: (label: unknown) => (typeof label === 'string' ? label : 'Files'),
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+// Render rows shallowly so the test focuses on FilesField behaviour.
+vi.mock('../FilesRow', () => ({
+  FilesRow: ({ rowIndex }: { rowIndex: number }) => (
+    <div data-testid={`files-row-${rowIndex}`}>row {rowIndex}</div>
+  ),
+}))
+vi.mock('../FilesFieldActions', () => ({
+  FilesFieldActions: () => <div data-testid="field-actions" />,
+}))
+vi.mock('../DragDropCustom', () => ({
+  DragDropCustomList: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dnd-list">{children}</div>
+  ),
+  DragDropCustomItem: ({
+    children,
+  }: {
+    children: (p: {
+      attributes: object
+      isDragging: boolean
+      listeners: object
+    }) => React.ReactNode
+  }) => <>{children({ attributes: {}, isDragging: false, listeners: {} })}</>,
+}))
+
+const baseProps = {
+  field: {
+    name: 'files',
+    label: 'Files',
+    fields: [],
+    required: true,
+    admin: { isSortable: true },
+  },
+  path: 'files',
+  permissions: {},
+  readOnly: false,
+  schemaPath: 'files',
+} as unknown as React.ComponentProps<typeof FilesField>
+
+const setField = (overrides: Record<string, unknown> = {}) => {
+  mockUseField.mockReturnValue({
+    customComponents: {},
+    disabled: false,
+    errorPaths: [],
+    path: 'files',
+    rows: [{ id: 'r0' }, { id: 'r1' }],
+    showError: false,
+    valid: true,
+    value: 2,
+    ...overrides,
+  })
+}
+
+describe('FilesField', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setField()
+  })
+
+  it('renders the field label and a row per value', () => {
+    render(<FilesField {...baseProps} />)
+    expect(screen.getByTestId('field-label')).toHaveTextContent('Files')
+    expect(screen.getByTestId('files-row-0')).toBeInTheDocument()
+    expect(screen.getByTestId('files-row-1')).toBeInTheDocument()
+  })
+
+  it('renders Collapse All / Show All header actions when rows exist', () => {
+    render(<FilesField {...baseProps} />)
+    expect(screen.getByText('fields:collapseAll')).toBeInTheDocument()
+    expect(screen.getByText('fields:showAll')).toBeInTheDocument()
+  })
+
+  it('renders the whole-field actions (copy/paste) menu', () => {
+    render(<FilesField {...baseProps} />)
+    expect(screen.getByTestId('field-actions')).toBeInTheDocument()
+  })
+
+  it('dispatches collapse-all when Collapse All is clicked', () => {
+    render(<FilesField {...baseProps} />)
+    fireEvent.click(screen.getByText('fields:collapseAll'))
+    expect(mockDispatchFields).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SET_ALL_ROWS_COLLAPSED', path: 'files' }),
+    )
+  })
+
+  it('dispatches show-all when Show All is clicked', () => {
+    render(<FilesField {...baseProps} />)
+    fireEvent.click(screen.getByText('fields:showAll'))
+    expect(mockSetDocFieldPreferences).toHaveBeenCalledWith('files', { collapsed: [] })
+  })
+
+  it('renders the add-row button when not at max rows', () => {
+    render(<FilesField {...baseProps} />)
+    expect(screen.getByTestId('add-row')).toBeInTheDocument()
+  })
+
+  it('hides header actions when there are no rows', () => {
+    setField({ rows: [], value: 0 })
+    render(<FilesField {...baseProps} />)
+    expect(screen.queryByText('fields:collapseAll')).toBeNull()
+  })
+
+  it('renders a field error when showError is set', () => {
+    setField({ showError: true })
+    render(<FilesField {...baseProps} />)
+    expect(screen.getByTestId('field-error')).toBeInTheDocument()
+  })
+
+  it('does not contain inline styles', () => {
+    const { container } = render(<FilesField {...baseProps} />)
+    expect(container.querySelector('[style]')).toBeNull()
+  })
+})

--- a/src/components/FilesField/index.tsx
+++ b/src/components/FilesField/index.tsx
@@ -1,0 +1,499 @@
+'use client'
+import React, { Fragment, useCallback, useId, useMemo } from 'react'
+import type { ArrayFieldClientComponent } from 'payload'
+import {
+  Banner,
+  Button,
+  ErrorPill,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  NullifyLocaleField,
+  RenderCustomComponent,
+  useConfig,
+  useDocumentInfo,
+  useField,
+  useForm,
+  useFormSubmitted,
+  useLocale,
+  useTranslation,
+} from '@payloadcms/ui'
+import { scrollToID } from '@payloadcms/ui/utilities/scrollToID'
+import { getTranslation } from '@payloadcms/translations'
+import { toast } from 'sonner'
+
+import { DragDropCustomItem, DragDropCustomList } from '../DragDropCustom'
+import { FilesFieldActions } from '../FilesFieldActions'
+import { FilesRow } from '../FilesRow'
+import {
+  clipboardCopy,
+  clipboardPaste,
+  mergeFormStateFromClipboard,
+  reduceFormStateByPath,
+} from '../utilities/clipboard'
+import './index.scss'
+
+const baseClass = 'files-field'
+
+type Row = { collapsed?: boolean; id: string }
+
+const extractRowsAndCollapsedIDs = ({
+  collapsed,
+  rowID,
+  rows,
+}: {
+  collapsed: boolean
+  rowID: string
+  rows: Row[]
+}) =>
+  rows.reduce<{ collapsedIDs: string[]; updatedRows: Row[] }>(
+    (acc, row) => {
+      const updatedRow = row.id === rowID ? { ...row, collapsed } : row
+      if (updatedRow.collapsed) {
+        acc.collapsedIDs.push(updatedRow.id)
+      }
+      acc.updatedRows.push(updatedRow)
+      return acc
+    },
+    { collapsedIDs: [], updatedRows: [] },
+  )
+
+const toggleAllRows = ({ collapsed, rows }: { collapsed: boolean; rows: Row[] }) =>
+  rows.reduce<{ collapsedIDs: string[]; updatedRows: Row[] }>(
+    (acc, row) => {
+      const updatedRow = { ...row, collapsed }
+      if (collapsed) {
+        acc.collapsedIDs.push(updatedRow.id)
+      }
+      acc.updatedRows.push(updatedRow)
+      return acc
+    },
+    { collapsedIDs: [], updatedRows: [] },
+  )
+
+export const FilesField: ArrayFieldClientComponent = (props) => {
+  const {
+    field,
+    field: {
+      name,
+      admin: { className, description, isSortable = true } = {},
+      fields,
+      label,
+      localized,
+      maxRows,
+      minRows: minRowsProp,
+      required,
+    } = {},
+    path: pathFromProps,
+    permissions,
+    readOnly,
+    schemaPath: schemaPathFromProps,
+    validate,
+  } = props
+
+  const schemaPath = schemaPathFromProps ?? name ?? ''
+  const minRows = minRowsProp ?? (required ? 1 : 0)
+
+  const { setDocFieldPreferences } = useDocumentInfo()
+  const {
+    addFieldRow,
+    dispatchFields,
+    getFields,
+    moveFieldRow,
+    removeFieldRow,
+    replaceState,
+    setModified,
+  } = useForm()
+  const submitted = useFormSubmitted()
+  const { code: locale } = useLocale()
+  const { i18n, t } = useTranslation()
+  const {
+    config: { localization },
+  } = useConfig()
+
+  const editingDefaultLocale = (() => {
+    if (localization && localization.fallback) {
+      const defaultLocale = localization.defaultLocale
+      return locale === defaultLocale
+    }
+    return true
+  })()
+
+  const labels = useMemo(() => {
+    if ('labels' in field && field.labels) {
+      return {
+        plural: field.labels?.plural,
+        singular: field.labels?.singular,
+      }
+    }
+    if ('label' in field && field.label) {
+      return { plural: undefined, singular: field.label }
+    }
+    return { plural: t('general:rows'), singular: t('general:row') }
+  }, [field, t])
+
+  const memoizedValidate = useCallback(
+    (value: unknown, options: Record<string, unknown>) => {
+      if (!editingDefaultLocale && value === null) {
+        return true
+      }
+      if (typeof validate === 'function') {
+        return validate(value as never, { ...options, maxRows, minRows, required } as never)
+      }
+    },
+    [maxRows, minRows, required, validate, editingDefaultLocale],
+  ) as never
+
+  const {
+    customComponents: { AfterInput, BeforeInput, Description, Error, Label } = {},
+    disabled,
+    errorPaths = [],
+    path,
+    rows = [],
+    showError,
+    valid,
+    value,
+  } = useField<number>({
+    hasRows: true,
+    potentiallyStalePath: pathFromProps,
+    validate: memoizedValidate,
+  })
+
+  const componentId = useId()
+  const scrollIdPrefix = useMemo(() => `scroll-${componentId}`, [componentId])
+
+  const addRow = useCallback(
+    (rowIndex: number) => {
+      void addFieldRow({ path, rowIndex, schemaPath })
+      setTimeout(() => {
+        scrollToID(`${scrollIdPrefix}-row-${rowIndex + 1}`)
+      }, 0)
+    },
+    [addFieldRow, path, schemaPath, scrollIdPrefix],
+  )
+
+  const duplicateRow = useCallback(
+    (rowIndex: number) => {
+      dispatchFields({ type: 'DUPLICATE_ROW', path, rowIndex })
+      setModified(true)
+      setTimeout(() => {
+        scrollToID(`${scrollIdPrefix}-row-${rowIndex + 1}`)
+      }, 0)
+    },
+    [dispatchFields, path, setModified, scrollIdPrefix],
+  )
+
+  const removeRow = useCallback(
+    (rowIndex: number) => {
+      removeFieldRow({ path, rowIndex })
+    },
+    [removeFieldRow, path],
+  )
+
+  const copyRow = useCallback(
+    (rowIndex: number) => {
+      const formState = { ...getFields() }
+      const clipboardResult = clipboardCopy({
+        type: 'array',
+        fields: fields ?? [],
+        getDataToCopy: () => reduceFormStateByPath({ formState, path, rowIndex }),
+        path,
+        rowIndex,
+        t,
+      })
+      if (typeof clipboardResult === 'string') {
+        toast.error(clipboardResult)
+      } else {
+        toast.success(t('general:copied'))
+      }
+    },
+    [fields, getFields, path, t],
+  )
+
+  const pasteRow = useCallback(
+    (rowIndex: number) => {
+      const formState = { ...getFields() }
+      const clipboardResult = clipboardPaste({
+        onPaste: (dataFromClipboard) => {
+          const newState = mergeFormStateFromClipboard({
+            dataFromClipboard,
+            formState,
+            path,
+            rowIndex,
+          })
+          replaceState(newState as never)
+          setModified(true)
+        },
+        path,
+        schemaFields: fields ?? [],
+        t,
+      })
+      if (typeof clipboardResult === 'string') {
+        toast.error(clipboardResult)
+      }
+    },
+    [fields, getFields, path, replaceState, setModified, t],
+  )
+
+  const moveRow = useCallback(
+    (moveFromIndex: number, moveToIndex: number) => {
+      moveFieldRow({ moveFromIndex, moveToIndex, path })
+    },
+    [path, moveFieldRow],
+  )
+
+  const copyField = useCallback(() => {
+    const formState = { ...getFields() }
+    const clipboardResult = clipboardCopy({
+      type: 'array',
+      fields: fields ?? [],
+      getDataToCopy: () => reduceFormStateByPath({ formState, path }),
+      path,
+      t,
+    })
+    if (typeof clipboardResult === 'string') {
+      toast.error(clipboardResult)
+    } else {
+      toast.success(t('general:copied'))
+    }
+  }, [fields, getFields, path, t])
+
+  const pasteField = useCallback(() => {
+    const formState = { ...getFields() }
+    const clipboardResult = clipboardPaste({
+      onPaste: (dataFromClipboard) => {
+        const newState = mergeFormStateFromClipboard({
+          dataFromClipboard,
+          formState,
+          path,
+        })
+        replaceState(newState as never)
+        setModified(true)
+      },
+      path,
+      schemaFields: fields ?? [],
+      t,
+    })
+    if (typeof clipboardResult === 'string') {
+      toast.error(clipboardResult)
+    }
+  }, [fields, getFields, path, replaceState, setModified, t])
+
+  const setCollapse = useCallback(
+    (rowID: string, collapsed: boolean) => {
+      const { collapsedIDs, updatedRows } = extractRowsAndCollapsedIDs({
+        collapsed,
+        rowID,
+        rows,
+      })
+      dispatchFields({
+        type: 'SET_ROW_COLLAPSED',
+        path,
+        updatedRows,
+      })
+      setDocFieldPreferences(path, { collapsed: collapsedIDs })
+    },
+    [dispatchFields, path, rows, setDocFieldPreferences],
+  )
+
+  const hasMaxRows = Boolean(maxRows && rows.length >= maxRows)
+  const toggleCollapseAll = useCallback(
+    (collapsed: boolean) => {
+      const { collapsedIDs, updatedRows } = toggleAllRows({ collapsed, rows })
+      dispatchFields({
+        type: 'SET_ALL_ROWS_COLLAPSED',
+        path,
+        updatedRows,
+      })
+      setDocFieldPreferences(path, { collapsed: collapsedIDs })
+    },
+    [dispatchFields, path, rows, setDocFieldPreferences],
+  )
+  const fieldErrorCount = errorPaths.length
+  const fieldHasErrors = submitted && errorPaths.length > 0
+  const showRequired = (readOnly || disabled) && rows.length === 0
+  const showMinRows = (rows.length && rows.length < minRows) || (required && rows.length === 0)
+
+  return (
+    <div
+      className={[
+        'field-type',
+        baseClass,
+        className,
+        fieldHasErrors ? `${baseClass}--has-error` : `${baseClass}--has-no-error`,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      id={`field-${path.replace(/\./g, '__')}`}
+    >
+      {showError && (
+        <RenderCustomComponent
+          CustomComponent={Error}
+          Fallback={<FieldError path={path} showError={showError} />}
+        />
+      )}
+      <header className={`${baseClass}__header`}>
+        <div className={`${baseClass}__header-wrap`}>
+          <div className={`${baseClass}__header-content`}>
+            <h3 className={`${baseClass}__title`}>
+              <RenderCustomComponent
+                CustomComponent={Label}
+                Fallback={
+                  <FieldLabel
+                    as="span"
+                    label={label}
+                    localized={localized}
+                    path={path}
+                    required={required}
+                  />
+                }
+              />
+            </h3>
+            {fieldHasErrors && fieldErrorCount > 0 && (
+              <ErrorPill count={fieldErrorCount} i18n={i18n} withMessage />
+            )}
+          </div>
+          {rows?.length > 0 && (
+            <ul className={`${baseClass}__header-actions`}>
+              <li>
+                <button
+                  className={`${baseClass}__header-action`}
+                  onClick={() => toggleCollapseAll(true)}
+                  type="button"
+                >
+                  {t('fields:collapseAll')}
+                </button>
+              </li>
+              <li>
+                <button
+                  className={`${baseClass}__header-action`}
+                  onClick={() => toggleCollapseAll(false)}
+                  type="button"
+                >
+                  {t('fields:showAll')}
+                </button>
+              </li>
+              <li>
+                <FilesFieldActions
+                  allowCopy={rows?.length > 0}
+                  allowPaste={!(readOnly || disabled)}
+                  copyField={copyField}
+                  disabled={disabled}
+                  pasteField={pasteField}
+                />
+              </li>
+            </ul>
+          )}
+        </div>
+        <RenderCustomComponent
+          CustomComponent={Description}
+          Fallback={<FieldDescription description={description} path={path} />}
+        />
+      </header>
+
+      <NullifyLocaleField
+        fieldValue={value}
+        localized={Boolean(localized)}
+        path={path}
+        readOnly={Boolean(readOnly)}
+      />
+
+      {BeforeInput}
+
+      {(rows?.length > 0 || (!valid && (showRequired || showMinRows))) && (
+        <DragDropCustomList
+          className={`${baseClass}__rows`}
+          ids={rows.map((row) => row.id)}
+          onDragEnd={({ moveFromIndex, moveToIndex }) => moveRow(moveFromIndex, moveToIndex)}
+        >
+          {rows.map((rowData, i) => {
+            const { id: rowID, isLoading } = rowData
+            const rowPath = `${path}.${i}`
+            const rowErrorCount = errorPaths?.filter((errorPath) =>
+              errorPath.startsWith(rowPath + '.'),
+            ).length
+
+            return (
+              <DragDropCustomItem
+                disabled={readOnly || disabled || !isSortable}
+                id={rowID}
+                key={rowID}
+              >
+                {({ attributes, isDragging, listeners }) => (
+                  <FilesRow
+                    addRow={addRow}
+                    attributes={attributes}
+                    copyRow={copyRow}
+                    duplicateRow={duplicateRow}
+                    errorCount={rowErrorCount}
+                    fields={fields}
+                    hasMaxRows={hasMaxRows}
+                    isDragging={isDragging}
+                    isLoading={isLoading}
+                    isSortable={Boolean(isSortable)}
+                    labels={labels}
+                    listeners={listeners}
+                    moveRow={moveRow}
+                    parentPath={path}
+                    path={rowPath}
+                    pasteRow={pasteRow}
+                    permissions={permissions}
+                    readOnly={readOnly || disabled}
+                    removeRow={removeRow}
+                    row={rowData}
+                    rowCount={rows?.length}
+                    rowIndex={i}
+                    schemaPath={schemaPath}
+                    scrollIdPrefix={scrollIdPrefix}
+                    setCollapse={setCollapse}
+                  />
+                )}
+              </DragDropCustomItem>
+            )
+          })}
+          {!valid && (
+            <Fragment>
+              {showRequired && (
+                <Banner>
+                  {t('validation:fieldHasNo', {
+                    label: getTranslation(labels.plural ?? '', i18n),
+                  })}
+                </Banner>
+              )}
+              {showMinRows && (
+                <Banner type="error">
+                  {t('validation:requiresAtLeast', {
+                    count: minRows,
+                    label:
+                      getTranslation((minRows > 1 ? labels.plural : labels.singular) ?? '', i18n) ||
+                      t(minRows > 1 ? 'general:rows' : 'general:row'),
+                  })}
+                </Banner>
+              )}
+            </Fragment>
+          )}
+        </DragDropCustomList>
+      )}
+
+      {!hasMaxRows && !readOnly && (
+        <Button
+          buttonStyle="icon-label"
+          className={`${baseClass}__add-row`}
+          disabled={disabled}
+          icon="plus"
+          iconPosition="left"
+          iconStyle="with-border"
+          onClick={() => {
+            void addRow(value || 0)
+          }}
+        >
+          {t('fields:addLabel', {
+            label: getTranslation(labels.singular ?? '', i18n),
+          })}
+        </Button>
+      )}
+
+      {AfterInput}
+    </div>
+  )
+}

--- a/src/components/FilesFieldActions/index.scss
+++ b/src/components/FilesFieldActions/index.scss
@@ -1,0 +1,43 @@
+.files-field-actions {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: calc(var(--base) / 2);
+
+  &__trigger {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-primary-darker, #1a4480);
+
+    svg .stroke,
+    svg .fill {
+      stroke: currentColor;
+    }
+  }
+
+  &__content {
+    position: absolute;
+    top: calc(100% + (var(--popup-caret-size, 8px) * 2));
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    z-index: calc(var(--z-popup, 100) + 2);
+  }
+
+  &__content .popup__caret {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+  }
+
+  &__content .popup__scroll-container {
+    max-height: none;
+    overflow-y: visible;
+  }
+
+  &__content .popup-button-list__button {
+    white-space: nowrap;
+  }
+}

--- a/src/components/FilesFieldActions/index.test.tsx
+++ b/src/components/FilesFieldActions/index.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { FilesFieldActions } from './index'
+
+vi.mock('@payloadcms/ui', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'general:copyField': 'Copy Field',
+        'general:pasteField': 'Paste Field',
+        'general:editLabel': 'Edit',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('@payloadcms/ui/icons/Copy', () => ({ CopyIcon: () => <svg data-testid="copy-icon" /> }))
+vi.mock('@payloadcms/ui/icons/Edit', () => ({ EditIcon: () => <svg data-testid="edit-icon" /> }))
+vi.mock('@payloadcms/ui/icons/More', () => ({ MoreIcon: () => <svg data-testid="more-icon" /> }))
+
+const setup = (overrides: Partial<React.ComponentProps<typeof FilesFieldActions>> = {}) => {
+  const copyField = vi.fn()
+  const pasteField = vi.fn()
+  const utils = render(
+    <FilesFieldActions
+      copyField={copyField}
+      pasteField={pasteField}
+      {...overrides}
+    />,
+  )
+  return { copyField, pasteField, ...utils }
+}
+
+describe('FilesFieldActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a closed three-dots trigger by default', () => {
+    setup()
+    const trigger = screen.getByRole('button')
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+    expect(screen.getByTestId('more-icon')).toBeInTheDocument()
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('opens the popup with Copy Field and Paste Field options', () => {
+    setup()
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(screen.getByText('Copy Field')).toBeInTheDocument()
+    expect(screen.getByText('Paste Field')).toBeInTheDocument()
+  })
+
+  it('calls copyField and closes the popup', () => {
+    const { copyField } = setup()
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByText('Copy Field'))
+
+    expect(copyField).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('calls pasteField and closes the popup', () => {
+    const { pasteField } = setup()
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByText('Paste Field'))
+
+    expect(pasteField).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('disables the copy option when allowCopy is false', () => {
+    setup({ allowCopy: false })
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('Copy Field').closest('button')).toBeDisabled()
+  })
+
+  it('disables the paste option when allowPaste is false', () => {
+    setup({ allowPaste: false })
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('Paste Field').closest('button')).toBeDisabled()
+  })
+
+  it('renders nothing when both copy and paste are disallowed', () => {
+    const { container } = setup({ allowCopy: false, allowPaste: false })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('closes the popup on Escape', () => {
+    setup()
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('does not contain inline styles', () => {
+    const { container } = setup()
+    fireEvent.click(screen.getByRole('button'))
+    expect(container.querySelector('[style]')).toBeNull()
+  })
+})

--- a/src/components/FilesFieldActions/index.tsx
+++ b/src/components/FilesFieldActions/index.tsx
@@ -1,0 +1,121 @@
+'use client'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from '@payloadcms/ui'
+import { CopyIcon } from '@payloadcms/ui/icons/Copy'
+import { EditIcon } from '@payloadcms/ui/icons/Edit'
+import { MoreIcon } from '@payloadcms/ui/icons/More'
+
+import './index.scss'
+
+const baseClass = 'files-field-actions'
+const arrayActionsClass = 'array-actions'
+
+type FilesFieldActionsProps = {
+  allowCopy?: boolean
+  allowPaste?: boolean
+  copyField: () => void
+  disabled?: boolean
+  pasteField: () => void
+}
+
+export const FilesFieldActions: React.FC<FilesFieldActionsProps> = ({
+  allowCopy = true,
+  allowPaste = true,
+  copyField,
+  disabled,
+  pasteField,
+}) => {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  const close = useCallback(() => setIsOpen(false), [])
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        close()
+      }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        close()
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('touchstart', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('touchstart', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen, close])
+
+  if (!allowCopy && !allowPaste) {
+    return null
+  }
+
+  const actionClass = `popup-button-list__button ${arrayActionsClass}__action`
+
+  return (
+    <div className={`${baseClass} ${arrayActionsClass}`} ref={containerRef}>
+      <button
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+        aria-label={t('general:editLabel', { label: '' })}
+        className={`${baseClass}__trigger ${arrayActionsClass}__button`}
+        disabled={disabled}
+        onClick={() => setIsOpen((prev) => !prev)}
+        type="button"
+      >
+        <MoreIcon />
+      </button>
+      {isOpen && (
+        <div className={`${baseClass}__content popup__content popup--size-medium popup--v-bottom`}>
+          <div className="popup__scroll-container">
+            <div
+              className="popup-button-list popup-button-list__text-align--left popup-button-list__button-size--small"
+              role="menu"
+            >
+              <button
+                className={`${actionClass} ${arrayActionsClass}__copy`}
+                disabled={!allowCopy}
+                onClick={() => {
+                  copyField()
+                  close()
+                }}
+                role="menuitem"
+                type="button"
+              >
+                <CopyIcon />
+                {t('general:copyField')}
+              </button>
+              <button
+                className={`${actionClass} ${arrayActionsClass}__paste`}
+                disabled={!allowPaste}
+                onClick={() => {
+                  pasteField()
+                  close()
+                }}
+                role="menuitem"
+                type="button"
+              >
+                <EditIcon />
+                {t('general:pasteField')}
+              </button>
+            </div>
+          </div>
+          <div className="popup__caret" />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/FilesRow/index.scss
+++ b/src/components/FilesRow/index.scss
@@ -1,0 +1,198 @@
+.files-field {
+  &__row {
+    position: relative;
+    border-radius: var(--style-radius-m, 4px);
+
+    &--popup-open {
+      z-index: calc(var(--z-popup, 100) + 10);
+    }
+
+    &--style-default {
+      border: 1px solid var(--theme-elevation-200);
+
+      &:hover {
+        border-color: var(--theme-elevation-300);
+      }
+    }
+
+    &--style-error {
+      border: 1px solid var(--theme-error-400);
+    }
+
+    &--is-dragging {
+      opacity: 0.6;
+    }
+  }
+
+  &__row-toggle-wrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: calc(var(--base) / 5);
+    width: 100%;
+    height: 40px;
+    padding: 0 calc(var(--base) / 2.5) 0 calc(var(--base) / 1.25);
+    line-height: calc(var(--base) * 1.2);
+    background: var(--theme-elevation-50);
+    border-top-left-radius: var(--style-radius-m, 4px);
+    border-top-right-radius: var(--style-radius-m, 4px);
+
+    &:hover {
+      background: var(--theme-elevation-100);
+    }
+
+    &:has(.files-field__row-drag) {
+      padding-inline-start: calc(var(--base) / 2.5);
+    }
+  }
+
+  &__row--style-error > &__row-toggle-wrap {
+    background: var(--theme-error-100);
+
+    &:hover {
+      background: var(--theme-error-150);
+    }
+
+    .files-field__row-label {
+      color: var(--theme-error-950);
+    }
+  }
+
+  &__row--collapsed &__row-toggle-wrap {
+    border-bottom-left-radius: var(--style-radius-m, 4px);
+    border-bottom-right-radius: var(--style-radius-m, 4px);
+  }
+
+  &__row-toggle {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    color: transparent;
+    text-align: left;
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 0;
+    border-top-left-radius: var(--style-radius-m, 4px);
+    border-top-right-radius: var(--style-radius-m, 4px);
+
+    span {
+      user-select: none;
+    }
+  }
+
+  &__row-drag {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.5;
+    width: calc(var(--base) * 1.2);
+    height: calc(var(--base) * 1.2);
+    padding: calc(var(--base) / 10);
+    cursor: grab;
+    position: relative;
+    z-index: 1;
+    touch-action: none;
+
+    &:active,
+    &--is-dragging {
+      cursor: grabbing;
+    }
+
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  &__row-header {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--base) / 2);
+    flex: 1;
+    overflow: hidden;
+    pointer-events: none;
+  }
+
+  &__row-actions-wrap {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--base) / 5);
+    position: relative;
+    z-index: 1;
+  }
+  
+  &__row--popup-open &__row-actions-wrap {
+    z-index: calc(var(--z-popup, 100) + 11);
+  }
+
+  &__row-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: calc(var(--base) * 1.2);
+    height: calc(var(--base) * 1.2);
+    padding: calc(var(--base) / 10);
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: currentColor;
+    cursor: pointer;
+    position: relative;
+    z-index: 1;
+  }
+
+  &__row-content-wrap {
+    display: grid;
+    grid-template-rows: 1fr;
+    transition: grid-template-rows 0.2s ease;
+  }
+
+  &__row--collapsed &__row-content-wrap {
+    grid-template-rows: 0fr;
+  }
+
+  &__row-content {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  &__row--open &__row-content {
+    background: var(--theme-elevation-0);
+    border-bottom-left-radius: var(--style-radius-m, 4px);
+    border-bottom-right-radius: var(--style-radius-m, 4px);
+  }
+
+  &__row-content-inner {
+    padding: var(--base);
+
+    > .field-type.upload,
+    .render-fields > .field-type.upload {
+      flex: 1 1 auto;
+    }
+  }
+
+  &__row-label {
+    pointer-events: none;
+    color: var(--theme-elevation-1000, #000);
+  }
+
+  &__row-shimmer {
+    display: inline-block;
+    width: 8rem;
+    height: 1rem;
+    border-radius: 3px;
+    background: var(--theme-elevation-100);
+  }
+
+  &__fields-shimmer {
+    display: block;
+    width: 100%;
+    height: 60px;
+    border-radius: 3px;
+    background: var(--theme-elevation-100);
+  }
+}

--- a/src/components/FilesRow/index.test.tsx
+++ b/src/components/FilesRow/index.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { FilesRow } from './index'
+
+vi.mock('@payloadcms/ui', () => ({
+  ErrorPill: ({ count }: { count: number }) => <span data-testid="error-pill">{count}</span>,
+  RenderFields: () => <div data-testid="render-fields" />,
+  useFormSubmitted: () => true,
+  useTranslation: () => ({ i18n: {}, t: (key: string) => key }),
+}))
+
+vi.mock('@payloadcms/ui/hooks/useThrottledValue', () => ({
+  useThrottledValue: (v: unknown) => v,
+}))
+
+vi.mock('@payloadcms/ui/icons/DragHandle', () => ({
+  DragHandleIcon: () => <svg data-testid="drag-handle" />,
+}))
+
+vi.mock('@payloadcms/translations', () => ({
+  getTranslation: (label: unknown) => (typeof label === 'string' ? label : 'File'),
+}))
+
+vi.mock('../icons/Chevron', () => ({
+  ChevronIcon: ({ direction }: { direction?: string }) => (
+    <svg data-testid="chevron-icon" data-direction={direction ?? 'down'} />
+  ),
+}))
+
+vi.mock('../FilesRowActions', () => ({
+  FilesRowActions: ({ onOpenChange }: { onOpenChange?: (o: boolean) => void }) => (
+    <button data-testid="row-actions" onClick={() => onOpenChange?.(true)} type="button">
+      actions
+    </button>
+  ),
+}))
+
+const baseProps = {
+  addRow: vi.fn(),
+  attributes: {},
+  copyRow: vi.fn(),
+  duplicateRow: vi.fn(),
+  isSortable: true,
+  labels: { singular: 'File' },
+  listeners: { onPointerDown: vi.fn() },
+  moveRow: vi.fn(),
+  parentPath: 'files',
+  path: 'files.1',
+  pasteRow: vi.fn(),
+  permissions: {},
+  removeRow: vi.fn(),
+  row: { collapsed: false, id: 'row-1' },
+  rowCount: 3,
+  rowIndex: 1,
+  scrollIdPrefix: 'scroll-1',
+  setCollapse: vi.fn(),
+}
+
+const setup = (overrides: Partial<React.ComponentProps<typeof FilesRow>> = {}) =>
+  render(<FilesRow {...baseProps} {...overrides} />)
+
+describe('FilesRow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the row label padded with the 1-based index', () => {
+    setup({ rowIndex: 0 })
+    expect(screen.getByText('File 01')).toBeInTheDocument()
+  })
+
+  it('renders the drag handle when sortable', () => {
+    setup({ isSortable: true })
+    expect(screen.getByTestId('drag-handle')).toBeInTheDocument()
+  })
+
+  it('hides the drag handle when not sortable', () => {
+    setup({ isSortable: false })
+    expect(screen.queryByTestId('drag-handle')).toBeNull()
+  })
+
+  it('renders RenderFields when not loading', () => {
+    setup({ isLoading: false })
+    expect(screen.getByTestId('render-fields')).toBeInTheDocument()
+  })
+
+  it('shows a shimmer placeholder when loading', () => {
+    const { container } = setup({ isLoading: true })
+    expect(container.querySelector('.files-field__fields-shimmer')).toBeInTheDocument()
+    expect(screen.queryByTestId('render-fields')).toBeNull()
+  })
+
+  it('toggles collapse when the indicator button is clicked', () => {
+    const setCollapse = vi.fn()
+    setup({ setCollapse, row: { collapsed: false, id: 'row-1' } })
+
+    const buttons = screen.getAllByRole('button')
+    // the collapse indicator is the last button (chevron); the hidden toggle
+    // overlay also calls setCollapse.
+    fireEvent.click(buttons[buttons.length - 1])
+    expect(setCollapse).toHaveBeenCalledWith('row-1', true)
+  })
+
+  it('renders the FilesRowActions when not read-only', () => {
+    setup({ readOnly: false })
+    expect(screen.getByTestId('row-actions')).toBeInTheDocument()
+  })
+
+  it('hides FilesRowActions when read-only', () => {
+    setup({ readOnly: true })
+    expect(screen.queryByTestId('row-actions')).toBeNull()
+  })
+
+  it('applies the popup-open class when the actions menu opens', () => {
+    const { container } = setup()
+    fireEvent.click(screen.getByTestId('row-actions'))
+    expect(container.querySelector('.files-field__row--popup-open')).toBeInTheDocument()
+  })
+
+  it('shows an error pill when the row has errors and the form was submitted', () => {
+    setup({ errorCount: 2 })
+    expect(screen.getByTestId('error-pill')).toHaveTextContent('2')
+  })
+
+  it('marks the row dragging via class when isDragging is true', () => {
+    const { container } = setup({ isDragging: true })
+    expect(container.querySelector('.files-field__row--is-dragging')).toBeInTheDocument()
+  })
+
+  it('does not contain inline styles', () => {
+    const { container } = setup()
+    expect(container.querySelector('[style]')).toBeNull()
+  })
+})

--- a/src/components/FilesRow/index.tsx
+++ b/src/components/FilesRow/index.tsx
@@ -1,0 +1,183 @@
+'use client'
+import React from 'react'
+import type { ClientField } from 'payload'
+import { ErrorPill, RenderFields, useFormSubmitted, useTranslation } from '@payloadcms/ui'
+import { useThrottledValue } from '@payloadcms/ui/hooks/useThrottledValue'
+import { DragHandleIcon } from '@payloadcms/ui/icons/DragHandle'
+import { getTranslation } from '@payloadcms/translations'
+
+import { ChevronIcon } from '../icons/Chevron'
+import { FilesRowActions } from '../FilesRowActions'
+import type { DragDropCustomItemRenderProps } from '../DragDropCustom'
+import './index.scss'
+
+const baseClass = 'files-field'
+
+type FilesRowProps = {
+  addRow: (rowIndex: number) => void
+  attributes: DragDropCustomItemRenderProps['attributes']
+  copyRow: (rowIndex: number) => void
+  duplicateRow: (rowIndex: number) => void
+  errorCount?: number
+  fields?: ClientField[]
+  forceRender?: boolean
+  hasMaxRows?: boolean
+  isDragging?: boolean
+  isLoading?: boolean
+  isSortable?: boolean
+  labels: { plural?: unknown; singular?: unknown }
+  listeners?: DragDropCustomItemRenderProps['listeners']
+  moveRow: (from: number, to: number) => void
+  parentPath: string
+  path: string
+  pasteRow: (rowIndex: number) => void
+  permissions: unknown
+  readOnly?: boolean
+  removeRow: (rowIndex: number) => void
+  row: { collapsed?: boolean; id: string }
+  rowCount: number
+  rowIndex: number
+  schemaPath?: string
+  scrollIdPrefix: string
+  setCollapse: (rowID: string, collapsed: boolean) => void
+}
+
+export const FilesRow: React.FC<FilesRowProps> = ({
+  addRow,
+  attributes,
+  copyRow,
+  duplicateRow,
+  errorCount,
+  fields,
+  forceRender = false,
+  hasMaxRows = false,
+  isDragging,
+  isLoading: isLoadingFromProps,
+  isSortable,
+  labels,
+  listeners,
+  moveRow,
+  parentPath,
+  path,
+  pasteRow,
+  permissions,
+  readOnly,
+  removeRow,
+  row,
+  rowCount,
+  rowIndex,
+  schemaPath,
+  scrollIdPrefix,
+  setCollapse,
+}) => {
+  const { i18n, t } = useTranslation()
+  const hasSubmitted = useFormSubmitted()
+  const [actionsOpen, setActionsOpen] = React.useState(false)
+
+  const isLoading = useThrottledValue(isLoadingFromProps, 500)
+
+  const fallbackLabel = `${getTranslation(labels.singular as string, i18n)} ${String(
+    rowIndex + 1,
+  ).padStart(2, '0')}`
+
+  const fieldHasErrors = (errorCount ?? 0) > 0 && hasSubmitted
+  const isCollapsed = Boolean(row.collapsed)
+
+  const classNames = [
+    `${baseClass}__row`,
+    actionsOpen ? `${baseClass}__row--popup-open` : '',
+    fieldHasErrors ? `${baseClass}__row--has-errors` : `${baseClass}__row--no-errors`,
+    isCollapsed ? `${baseClass}__row--collapsed` : `${baseClass}__row--open`,
+    fieldHasErrors ? `${baseClass}__row--style-error` : `${baseClass}__row--style-default`,
+    isDragging ? `${baseClass}__row--is-dragging` : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div
+      className={classNames}
+      id={`${parentPath.split('.').join('-')}-row-${rowIndex}`}
+    >
+      <div className={`${baseClass}__row-toggle-wrap`}>
+        <button
+          aria-expanded={!isCollapsed}
+          className={`${baseClass}__row-toggle`}
+          onClick={() => setCollapse(row.id, !isCollapsed)}
+          type="button"
+        >
+          <span>{t('fields:toggleBlock')}</span>
+        </button>
+        {isSortable && (
+          <div
+            className={[
+              `${baseClass}__row-drag`,
+              isDragging ? `${baseClass}__row-drag--is-dragging` : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            {...attributes}
+            {...listeners}
+          >
+            <DragHandleIcon />
+          </div>
+        )}
+        <div className={`${baseClass}__row-header`} id={`${scrollIdPrefix}-row-${rowIndex}`}>
+          {isLoading ? (
+            <span className={`${baseClass}__row-shimmer`} />
+          ) : (
+            <span className={`${baseClass}__row-label`}>{fallbackLabel}</span>
+          )}
+          {fieldHasErrors && <ErrorPill count={errorCount ?? 0} i18n={i18n} withMessage />}
+        </div>
+        <div className={`${baseClass}__row-actions-wrap`}>
+          {!readOnly && (
+            <FilesRowActions
+              addRow={addRow}
+              copyRow={copyRow}
+              duplicateRow={duplicateRow}
+              hasMaxRows={hasMaxRows}
+              index={rowIndex}
+              isSortable={isSortable}
+              moveRow={moveRow}
+              onOpenChange={setActionsOpen}
+              pasteRow={pasteRow}
+              removeRow={removeRow}
+              rowCount={rowCount}
+            />
+          )}
+          <button
+            aria-expanded={!isCollapsed}
+            aria-label={t('fields:toggleBlock')}
+            className={`${baseClass}__row-indicator`}
+            onClick={() => setCollapse(row.id, !isCollapsed)}
+            type="button"
+          >
+            <ChevronIcon direction={isCollapsed ? undefined : 'up'} />
+          </button>
+        </div>
+      </div>
+      <div className={`${baseClass}__row-content-wrap`}>
+        <div className={`${baseClass}__row-content`}>
+          <div className={`${baseClass}__row-content-inner`}>
+            {isLoading ? (
+              <span className={`${baseClass}__fields-shimmer`} />
+            ) : (
+              <RenderFields
+                className={`${baseClass}__fields`}
+                fields={fields ?? []}
+                forceRender={forceRender}
+                margins="small"
+                parentIndexPath=""
+                parentPath={path}
+                parentSchemaPath={schemaPath ?? ''}
+                permissions={permissions === true ? permissions : (permissions as any)?.fields}
+                readOnly={readOnly}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/FilesRowActions/index.scss
+++ b/src/components/FilesRowActions/index.scss
@@ -1,0 +1,36 @@
+.files-row-actions {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &__trigger {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__content {
+    position: absolute;
+    top: calc(100% + (var(--popup-caret-size, 8px) * 2));
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    z-index: calc(var(--z-popup, 100) + 2);
+  }
+
+  &__content .popup__caret {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+  }
+
+  &__content .popup__scroll-container {
+    max-height: none;
+    overflow-y: visible;
+  }
+
+  &__content .popup-button-list__button {
+    white-space: nowrap;
+  }
+}

--- a/src/components/FilesRowActions/index.test.tsx
+++ b/src/components/FilesRowActions/index.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { FilesRowActions } from './index'
+
+vi.mock('@payloadcms/ui', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'general:moveUp': 'Move Up',
+        'general:moveDown': 'Move Down',
+        'general:addBelow': 'Add Below',
+        'general:duplicate': 'Duplicate',
+        'general:copyRow': 'Copy Row',
+        'general:pasteRow': 'Paste Row',
+        'general:remove': 'Remove',
+        'general:editLabel': 'Edit',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('@payloadcms/ui/icons/Copy', () => ({ CopyIcon: () => <svg data-testid="copy-icon" /> }))
+vi.mock('@payloadcms/ui/icons/Edit', () => ({ EditIcon: () => <svg data-testid="edit-icon" /> }))
+vi.mock('@payloadcms/ui/icons/More', () => ({ MoreIcon: () => <svg data-testid="more-icon" /> }))
+vi.mock('@payloadcms/ui/icons/Plus', () => ({ PlusIcon: () => <svg data-testid="plus-icon" /> }))
+vi.mock('@payloadcms/ui/icons/X', () => ({ XIcon: () => <svg data-testid="x-icon" /> }))
+vi.mock('../icons/Chevron', () => ({
+  ChevronIcon: ({ direction }: { direction?: string }) => (
+    <svg data-testid="chevron-icon" data-direction={direction ?? 'down'} />
+  ),
+}))
+
+const baseProps = {
+  addRow: vi.fn(),
+  copyRow: vi.fn(),
+  duplicateRow: vi.fn(),
+  index: 1,
+  isSortable: true,
+  moveRow: vi.fn(),
+  pasteRow: vi.fn(),
+  removeRow: vi.fn(),
+  rowCount: 3,
+}
+
+const setup = (overrides: Partial<React.ComponentProps<typeof FilesRowActions>> = {}) =>
+  render(<FilesRowActions {...baseProps} {...overrides} />)
+
+describe('FilesRowActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a closed three-dots trigger', () => {
+    setup()
+    const trigger = screen.getByRole('button')
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByTestId('more-icon')).toBeInTheDocument()
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('opens the menu with all actions for a middle, sortable row', () => {
+    setup()
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('Move Up')).toBeInTheDocument()
+    expect(screen.getByText('Move Down')).toBeInTheDocument()
+    expect(screen.getByText('Add Below')).toBeInTheDocument()
+    expect(screen.getByText('Duplicate')).toBeInTheDocument()
+    expect(screen.getByText('Copy Row')).toBeInTheDocument()
+    expect(screen.getByText('Paste Row')).toBeInTheDocument()
+    expect(screen.getByText('Remove')).toBeInTheDocument()
+  })
+
+  it('hides Move Up for the first row', () => {
+    setup({ index: 0 })
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.queryByText('Move Up')).toBeNull()
+    expect(screen.getByText('Move Down')).toBeInTheDocument()
+  })
+
+  it('hides Move Down for the last row', () => {
+    setup({ index: 2, rowCount: 3 })
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('Move Up')).toBeInTheDocument()
+    expect(screen.queryByText('Move Down')).toBeNull()
+  })
+
+  it('hides move actions entirely when not sortable', () => {
+    setup({ isSortable: false })
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.queryByText('Move Up')).toBeNull()
+    expect(screen.queryByText('Move Down')).toBeNull()
+  })
+
+  it('hides Add Below and Duplicate when hasMaxRows', () => {
+    setup({ hasMaxRows: true })
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.queryByText('Add Below')).toBeNull()
+    expect(screen.queryByText('Duplicate')).toBeNull()
+    // Copy / Paste / Remove are still present.
+    expect(screen.getByText('Copy Row')).toBeInTheDocument()
+  })
+
+  it('calls moveRow up/down with the right indexes', () => {
+    const moveRow = vi.fn()
+    setup({ moveRow })
+    fireEvent.click(screen.getByRole('button'))
+
+    fireEvent.click(screen.getByText('Move Up'))
+    expect(moveRow).toHaveBeenCalledWith(1, 0)
+
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByText('Move Down'))
+    expect(moveRow).toHaveBeenCalledWith(1, 2)
+  })
+
+  it('invokes add/duplicate/copy/paste/remove callbacks', () => {
+    const addRow = vi.fn()
+    const duplicateRow = vi.fn()
+    const copyRow = vi.fn()
+    const pasteRow = vi.fn()
+    const removeRow = vi.fn()
+    setup({ addRow, duplicateRow, copyRow, pasteRow, removeRow })
+
+    const open = () => fireEvent.click(screen.getByRole('button'))
+
+    open()
+    fireEvent.click(screen.getByText('Add Below'))
+    expect(addRow).toHaveBeenCalledWith(2)
+
+    open()
+    fireEvent.click(screen.getByText('Duplicate'))
+    expect(duplicateRow).toHaveBeenCalledWith(1)
+
+    open()
+    fireEvent.click(screen.getByText('Copy Row'))
+    expect(copyRow).toHaveBeenCalledWith(1)
+
+    open()
+    fireEvent.click(screen.getByText('Paste Row'))
+    expect(pasteRow).toHaveBeenCalledWith(1)
+
+    open()
+    fireEvent.click(screen.getByText('Remove'))
+    expect(removeRow).toHaveBeenCalledWith(1)
+  })
+
+  it('reports open state changes via onOpenChange', () => {
+    const onOpenChange = vi.fn()
+    setup({ onOpenChange })
+
+    // Called with false on mount.
+    expect(onOpenChange).toHaveBeenLastCalledWith(false)
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(onOpenChange).toHaveBeenLastCalledWith(true)
+  })
+
+  it('closes the menu on Escape', () => {
+    setup()
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('does not contain inline styles', () => {
+    const { container } = setup()
+    fireEvent.click(screen.getByRole('button'))
+    expect(container.querySelector('[style]')).toBeNull()
+  })
+})

--- a/src/components/FilesRowActions/index.tsx
+++ b/src/components/FilesRowActions/index.tsx
@@ -1,0 +1,209 @@
+'use client'
+import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from '@payloadcms/ui'
+import { CopyIcon } from '@payloadcms/ui/icons/Copy'
+import { EditIcon } from '@payloadcms/ui/icons/Edit'
+import { MoreIcon } from '@payloadcms/ui/icons/More'
+import { PlusIcon } from '@payloadcms/ui/icons/Plus'
+import { XIcon } from '@payloadcms/ui/icons/X'
+
+import { ChevronIcon } from '../icons/Chevron'
+
+import './index.scss'
+
+const baseClass = 'files-row-actions'
+const arrayActionsClass = 'array-actions'
+
+type FilesRowActionsProps = {
+  addRow: (rowIndex: number) => void
+  copyRow: (rowIndex: number) => void
+  duplicateRow: (rowIndex: number) => void
+  hasMaxRows?: boolean
+  index: number
+  isSortable?: boolean
+  moveRow: (from: number, to: number) => void
+  onOpenChange?: (open: boolean) => void
+  pasteRow: (rowIndex: number) => void
+  removeRow: (rowIndex: number) => void
+  rowCount: number
+}
+
+export const FilesRowActions: React.FC<FilesRowActionsProps> = ({
+  addRow,
+  copyRow,
+  duplicateRow,
+  hasMaxRows = false,
+  index,
+  isSortable,
+  moveRow,
+  onOpenChange,
+  pasteRow,
+  removeRow,
+  rowCount,
+}) => {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  const close = useCallback(() => setIsOpen(false), [])
+
+  useEffect(() => {
+    onOpenChange?.(isOpen)
+  }, [isOpen, onOpenChange])
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        close()
+      }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        close()
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('touchstart', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('touchstart', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen, close])
+
+  const canMoveUp = Boolean(isSortable) && index !== 0
+  const canMoveDown = Boolean(isSortable) && index < rowCount - 1
+
+  const actionClass = `popup-button-list__button ${arrayActionsClass}__action`
+
+  return (
+    <div className={`${baseClass} ${arrayActionsClass}`} ref={containerRef}>
+      <button
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+        aria-label={t('general:editLabel', { label: '' })}
+        className={`${baseClass}__trigger ${arrayActionsClass}__button`}
+        onClick={() => setIsOpen((prev) => !prev)}
+        type="button"
+      >
+        <MoreIcon />
+      </button>
+      {isOpen && (
+        <div className={`${baseClass}__content popup__content popup--size-medium popup--v-bottom`}>
+          <div className="popup__scroll-container">
+            <div
+              className="popup-button-list popup-button-list__text-align--left popup-button-list__button-size--small"
+              role="menu"
+            >
+              {canMoveUp && (
+                <button
+                  className={`${actionClass} ${arrayActionsClass}__move-up`}
+                  onClick={() => {
+                    moveRow(index, index - 1)
+                    close()
+                  }}
+                  role="menuitem"
+                  type="button"
+                >
+                  <span className={`${arrayActionsClass}__action-chevron`}>
+                    <ChevronIcon direction="up" />
+                  </span>
+                  {t('general:moveUp')}
+                </button>
+              )}
+              {canMoveDown && (
+                <button
+                  className={`${actionClass} ${arrayActionsClass}__move-down`}
+                  onClick={() => {
+                    moveRow(index, index + 1)
+                    close()
+                  }}
+                  role="menuitem"
+                  type="button"
+                >
+                  <span className={`${arrayActionsClass}__action-chevron`}>
+                    <ChevronIcon />
+                  </span>
+                  {t('general:moveDown')}
+                </button>
+              )}
+              {!hasMaxRows && (
+                <Fragment>
+                  <button
+                    className={`${actionClass} ${arrayActionsClass}__add`}
+                    onClick={() => {
+                      addRow(index + 1)
+                      close()
+                    }}
+                    role="menuitem"
+                    type="button"
+                  >
+                    <PlusIcon />
+                    {t('general:addBelow')}
+                  </button>
+                  <button
+                    className={`${actionClass} ${arrayActionsClass}__duplicate`}
+                    onClick={() => {
+                      duplicateRow(index)
+                      close()
+                    }}
+                    role="menuitem"
+                    type="button"
+                  >
+                    <CopyIcon />
+                    {t('general:duplicate')}
+                  </button>
+                </Fragment>
+              )}
+              <button
+                className={`${actionClass} ${arrayActionsClass}__copy`}
+                onClick={() => {
+                  copyRow(index)
+                  close()
+                }}
+                role="menuitem"
+                type="button"
+              >
+                <CopyIcon />
+                {t('general:copyRow')}
+              </button>
+              <button
+                className={`${actionClass} ${arrayActionsClass}__paste`}
+                onClick={() => {
+                  pasteRow(index)
+                  close()
+                }}
+                role="menuitem"
+                type="button"
+              >
+                <EditIcon />
+                {t('general:pasteRow')}
+              </button>
+              <button
+                className={`${actionClass} ${arrayActionsClass}__remove`}
+                onClick={() => {
+                  removeRow(index)
+                  close()
+                }}
+                role="menuitem"
+                type="button"
+              >
+                <XIcon />
+                {t('general:remove')}
+              </button>
+            </div>
+          </div>
+          <div className="popup__caret" />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/icons/Chevron/index.scss
+++ b/src/components/icons/Chevron/index.scss
@@ -1,0 +1,33 @@
+.icon--chevron {
+  height: var(--base);
+  width: var(--base);
+
+  .stroke {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1px;
+    vector-effect: non-scaling-stroke;
+  }
+
+  &.icon--size-large {
+    height: var(--base);
+    width: var(--base);
+  }
+
+  &.icon--size-small {
+    height: 12px;
+    width: 12px;
+  }
+
+  &.icon--chevron--up {
+    transform: rotate(180deg);
+  }
+
+  &.icon--chevron--left {
+    transform: rotate(90deg);
+  }
+
+  &.icon--chevron--right {
+    transform: rotate(-90deg);
+  }
+}

--- a/src/components/icons/Chevron/index.tsx
+++ b/src/components/icons/Chevron/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import './index.scss'
+
+type ChevronIconProps = {
+  ariaLabel?: string
+  className?: string
+  direction?: 'down' | 'left' | 'right' | 'up'
+  size?: 'large' | 'small'
+}
+
+export const ChevronIcon: React.FC<ChevronIconProps> = ({
+  ariaLabel,
+  className,
+  direction,
+  size,
+}) => (
+  <svg
+    aria-label={ariaLabel}
+    className={[
+      'icon icon--chevron',
+      direction ? `icon--chevron--${direction}` : '',
+      size ? `icon--size-${size}` : '',
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ')}
+    height="100%"
+    viewBox="0 0 20 20"
+    width="100%"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path className="stroke" d="M14 8L10 12L6 8" strokeLinecap="square" />
+  </svg>
+)

--- a/src/components/utilities/clipboard.ts
+++ b/src/components/utilities/clipboard.ts
@@ -1,0 +1,315 @@
+/**
+ * Local port of Payload's clipboard utilities for array rows.
+ *
+ * These helpers live in `@payloadcms/ui` but are not part of the package's
+ * public `exports` map (only deep, non-exported `dist/...` paths), so they
+ * cannot be imported directly. The logic is copied verbatim from
+ * `@payloadcms/ui/dist/elements/ClipboardAction/*` to keep behaviour identical
+ * to the stock array field's Copy Row / Paste Row actions.
+ */
+import type { TFunction } from '@payloadcms/translations'
+import type { ClientBlock, ClientField } from 'payload'
+import { fieldAffectsData, fieldHasSubFields } from 'payload/shared'
+import ObjectIdImport from 'bson-objectid'
+
+const ObjectId = (
+  'default' in ObjectIdImport ? ObjectIdImport.default : ObjectIdImport
+) as typeof ObjectIdImport
+
+const localStorageClipboardKey = '_payloadClipboard'
+
+type FormState = Record<string, any>
+
+type ClipboardCopyData = {
+  path: string
+  rowIndex?: number
+} & ({ blocks: ClientBlock[]; type: 'blocks' } | { fields: ClientField[]; type: 'array' })
+
+type ClipboardCopyActionArgs = {
+  getDataToCopy: () => FormState
+  t: TFunction
+} & ClipboardCopyData
+
+type ClipboardPasteData = {
+  data: FormState
+  path: string
+  rowIndex?: number
+} & ({ blocks: ClientBlock[]; type: 'blocks' } | { fields: ClientField[]; type: 'array' })
+
+type ClipboardPasteActionArgs = {
+  onPaste: (data: ClipboardPasteData) => void
+  path: string
+  t: TFunction
+} & ({ schemaBlocks: ClientBlock[] } | { schemaFields: ClientField[] })
+
+
+export function clipboardCopy(args: ClipboardCopyActionArgs): string | true {
+  const { getDataToCopy, t, ...rest } = args
+  const dataToWrite = { data: getDataToCopy(), ...rest }
+  try {
+    localStorage.setItem(localStorageClipboardKey, JSON.stringify(dataToWrite))
+    return true
+  } catch (_err) {
+    return t('error:unableToCopy')
+  }
+}
+
+export function clipboardPaste({
+  onPaste,
+  path: fieldPath,
+  t,
+  ...args
+}: ClipboardPasteActionArgs): string | true {
+  let dataToPaste: any
+  try {
+    const jsonFromClipboard = localStorage.getItem(localStorageClipboardKey)
+    if (!jsonFromClipboard) {
+      return t('error:invalidClipboardData')
+    }
+    dataToPaste = JSON.parse(jsonFromClipboard)
+  } catch (_err) {
+    return t('error:invalidClipboardData')
+  }
+
+  const dataToValidate = { ...dataToPaste, ...args, fieldPath }
+
+  if (!isClipboardDataValid(dataToValidate)) {
+    return t('error:invalidClipboardData')
+  }
+
+  onPaste(dataToPaste)
+  return true
+}
+
+function isClipboardDataValid({ data, path, ...args }: any): boolean {
+  if (typeof data === 'undefined' || !path || !args.type) {
+    return false
+  }
+  if (args.type === 'blocks') {
+    return isClipboardBlocksValid({
+      blocksFromClipboard: args.blocks,
+      blocksFromConfig: args.schemaBlocks,
+    })
+  }
+  return isClipboardFieldsValid({
+    fieldsFromClipboard: args.fields,
+    fieldsFromConfig: args.schemaFields,
+  })
+}
+
+function isClipboardFieldsValid({ fieldsFromClipboard, fieldsFromConfig }: any): boolean {
+  if (!fieldsFromConfig || fieldsFromClipboard.length !== fieldsFromConfig?.length) {
+    return false
+  }
+  return fieldsFromClipboard.every((clipboardField: any, i: number) => {
+    const configField = fieldsFromConfig[i]
+    if (clipboardField.type !== configField.type) {
+      return false
+    }
+    const affectsData = fieldAffectsData(clipboardField) && fieldAffectsData(configField)
+    if (affectsData && clipboardField.name !== configField.name) {
+      return false
+    }
+    const hasNestedFieldsConfig = fieldHasSubFields(configField)
+    const hasNestedFieldsClipboard = fieldHasSubFields(clipboardField)
+    if (hasNestedFieldsClipboard !== hasNestedFieldsConfig) {
+      return false
+    }
+    if (hasNestedFieldsClipboard && hasNestedFieldsConfig) {
+      return isClipboardFieldsValid({
+        fieldsFromClipboard: clipboardField.fields,
+        fieldsFromConfig: configField.fields,
+      })
+    }
+    return true
+  })
+}
+
+function isClipboardBlocksValid({ blocksFromClipboard, blocksFromConfig }: any): boolean {
+  const configBlockMap = new Map(blocksFromConfig?.map((block: any) => [block.slug, block]))
+  if (!configBlockMap.size) {
+    return false
+  }
+  const checkedSlugs = new Set<string>()
+  for (const currBlock of blocksFromClipboard) {
+    const currSlug = currBlock.slug
+    if (!checkedSlugs.has(currSlug)) {
+      const configBlock = configBlockMap.get(currSlug) as any
+      if (!configBlock) {
+        return false
+      }
+      if (
+        !isClipboardFieldsValid({
+          fieldsFromClipboard: currBlock.fields,
+          fieldsFromConfig: configBlock.fields,
+        })
+      ) {
+        return false
+      }
+      checkedSlugs.add(currSlug)
+    }
+  }
+  return true
+}
+
+export function reduceFormStateByPath({
+  formState,
+  path,
+  rowIndex,
+}: {
+  formState: FormState
+  path: string
+  rowIndex?: number
+}): FormState {
+  const filteredState: FormState = {}
+  const prefix = typeof rowIndex !== 'number' ? path : `${path}.${rowIndex}`
+  for (const key in formState) {
+    if (!key.startsWith(prefix)) {
+      continue
+    }
+    const { customComponents: _, validate: __, ...field } = formState[key]
+    if (Array.isArray(field.rows)) {
+      field.rows = field.rows.map((row: any) => {
+        if (!row || typeof row !== 'object') {
+          return row
+        }
+        const { customComponents: _c, ...serializableRow } = row
+        return serializableRow
+      })
+    }
+    filteredState[key] = field
+  }
+  return filteredState
+}
+
+export function mergeFormStateFromClipboard({
+  dataFromClipboard: clipboardData,
+  formState,
+  path,
+  rowIndex,
+}: {
+  dataFromClipboard: ClipboardPasteData
+  formState: FormState
+  path: string
+  rowIndex?: number
+}): FormState {
+  const {
+    type: typeFromClipboard,
+    data: dataFromClipboard,
+    path: pathFromClipboard,
+    rowIndex: rowIndexFromClipboard,
+  } = clipboardData
+
+  const copyFromField = typeof rowIndexFromClipboard !== 'number'
+  const pasteIntoField = typeof rowIndex !== 'number'
+  const fromRowToField = !copyFromField && pasteIntoField
+  const isArray = typeFromClipboard === 'array'
+
+  let pathToReplace: string
+  if (copyFromField && pasteIntoField) {
+    pathToReplace = pathFromClipboard
+  } else if (copyFromField) {
+    pathToReplace = `${pathFromClipboard}.${rowIndex}`
+  } else {
+    pathToReplace = `${pathFromClipboard}.${rowIndexFromClipboard}`
+  }
+
+  let targetSegment: string
+  if (!pasteIntoField) {
+    targetSegment = `${path}.${rowIndex}`
+  } else if (fromRowToField) {
+    targetSegment = `${path}.0`
+  } else {
+    targetSegment = path
+  }
+
+  if (fromRowToField) {
+    const lastRenderedPath = `${path}.0`
+    const rowIDFromClipboard = dataFromClipboard[`${pathToReplace}.id`]?.value
+    const hasRows = formState[path].rows?.length
+    formState[path].rows = [
+      {
+        ...(hasRows && isArray ? formState[path].rows[0] : {}),
+        id: rowIDFromClipboard,
+        isLoading: false,
+        lastRenderedPath,
+      },
+    ]
+    formState[path].value = 1
+    formState[path].initialValue = 1
+    formState[path].disableFormData = true
+    for (const fieldPath in formState) {
+      if (
+        fieldPath !== path &&
+        !fieldPath.startsWith(lastRenderedPath) &&
+        fieldPath.startsWith(path)
+      ) {
+        delete formState[fieldPath]
+      }
+    }
+  }
+
+  const idReplacements = new Map<string, string>()
+  for (const clipboardPath in dataFromClipboard) {
+    if (
+      (!pasteIntoField && clipboardPath === `${pathToReplace}.id`) ||
+      !clipboardPath.startsWith(pathToReplace)
+    ) {
+      continue
+    }
+    const newPath = clipboardPath.replace(pathToReplace, targetSegment)
+    const customComponents = isArray ? formState[newPath]?.customComponents : undefined
+    const validate = isArray ? formState[newPath]?.validate : undefined
+    if (clipboardPath.endsWith('.id') && dataFromClipboard[clipboardPath]?.value) {
+      const oldID = dataFromClipboard[clipboardPath].value
+      if (typeof oldID === 'string' && ObjectId.isValid(oldID)) {
+        const newID = new ObjectId().toHexString()
+        idReplacements.set(clipboardPath, newID)
+        formState[newPath] = {
+          customComponents,
+          validate,
+          ...dataFromClipboard[clipboardPath],
+          initialValue: newID,
+          value: newID,
+        }
+        continue
+      }
+    }
+    formState[newPath] = {
+      customComponents,
+      validate,
+      ...dataFromClipboard[clipboardPath],
+    }
+  }
+
+  for (const [clipboardPath, newID] of idReplacements) {
+    const relativePath = clipboardPath.replace(`${pathToReplace}.`, '')
+    const segments = relativePath.split('.')
+    if (segments.length >= 2) {
+      const segmentRowIndex = parseInt(segments[segments.length - 2], 10)
+      const parentFieldPath = segments.slice(0, segments.length - 2).join('.')
+      const fullParentPath = parentFieldPath ? `${targetSegment}.${parentFieldPath}` : targetSegment
+      if (formState[fullParentPath] && Array.isArray(formState[fullParentPath].rows)) {
+        const parentRows = formState[fullParentPath].rows
+        if (!isNaN(segmentRowIndex) && parentRows[segmentRowIndex]) {
+          parentRows[segmentRowIndex].id = newID
+        }
+      }
+    } else if (segments.length === 1 && segments[0] === 'id') {
+      const targetParts = targetSegment.split('.')
+      const lastPart = targetParts[targetParts.length - 1]
+      const rowIndexFromTarget = !isNaN(parseInt(lastPart, 10)) ? parseInt(lastPart, 10) : 0
+      const fieldPath = !isNaN(parseInt(lastPart, 10))
+        ? targetParts.slice(0, -1).join('.')
+        : targetSegment
+      if (formState[fieldPath] && Array.isArray(formState[fieldPath].rows)) {
+        const rows = formState[fieldPath].rows
+        if (rows[rowIndexFromTarget]) {
+          rows[rowIndexFromTarget].id = newID
+        }
+      }
+    }
+  }
+
+  return formState
+}

--- a/src/fields/commonFields.ts
+++ b/src/fields/commonFields.ts
@@ -248,6 +248,9 @@ export const filesField: ArrayField = {
   type: 'array',
   admin: {
     description: 'Add downloadable files or attachments',
+    components: {
+      Field: '@/components/FilesField#FilesField',
+    },
   },
   fields: [
     {
@@ -255,6 +258,11 @@ export const filesField: ArrayField = {
       type: 'upload',
       relationTo: 'media',
       required: true,
+      admin: {
+        components: {
+          Field: '@/components/FileUploadField#FileUploadField',
+        },
+      },
     },
     {
       name: 'label',


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove inline css field array

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
